### PR TITLE
Fix prettier formatting in results app.css (unbreaks CI for all PRs)

### DIFF
--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -133,7 +133,6 @@ main.error-page {
 }
 
 table {
-
   th,
   td {
     padding: 0.25rem 0.5rem;
@@ -149,7 +148,6 @@ table {
     display: flex;
     position: relative;
     justify-content: end;
-
 
     .units {
       position: absolute;


### PR DESCRIPTION
`results/app/styles/app.css` on `main` currently fails `prettier --check` (two extra blank lines), so the **Results App / Lint** job fails for every open PR — including #19, which doesn't touch `results/` at all.

This removes the two blank lines (`prettier --write`, no other changes). All four `results` lint jobs pass locally after this.

Once this lands, re-running CI on #19 should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)