### PR TITLE
Runner: install common's deps before building apps (fixes faker-js build failure)

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -98,6 +98,17 @@ const browser = await puppeteer.launch({
 if (!SKIP_BUILD) {
   clack.log.info(`Building Projects`);
 
+  /**
+   * The apps depend on `common` via the link: protocol,
+   * and pnpm does not install dependencies *of* linked packages --
+   * so without this, every app build fails to resolve
+   * `@faker-js/faker` (imported by the dbmon chat-worker,
+   * which vite bundles for every app, because common's index
+   * imports every test).
+   */
+  console.info(`Installing dependencies of the linked \`common\` package`);
+  await $({ preferLocal: true, cwd: 'common', stdio: 'inherit' })`pnpm install`;
+
   for (const framework of info.frameworks) {
     for (const app of info.apps) {
       const dir = join('frameworks', framework, app);


### PR DESCRIPTION
Running `pnpm bench` can fail during the build step with:

```
[vite:worker-import-meta-url] [vite]: Rollup failed to resolve import "@faker-js/faker"
from ".../common/src/tests/dbmon/chat-worker.js"
```

**Why:** every app depends on `common` via the `link:` protocol, and pnpm does not install dependencies *of* linked packages — the apps' own `pnpm install` (which the runner performs) never materializes `common/node_modules`. Vite bundles the dbmon workers for **every** app, because `common/src/index.js` imports every test, so the missing `@faker-js/faker` breaks all app builds — not just dbmon. It only ever worked when the root install's `prepare` hook (`install:common`) had already populated `common/node_modules`; a fresh clone, a pruned store, or skipping the root install breaks it.

**Fix:** the runner installs `common`'s deps once, up front, before building the selected apps.

Verified locally: with `common/node_modules` deleted, app builds reproduce the error; after this change (install common → install app → build app, exactly the runner's sequence) the build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)