### PR TITLE
Fix ember dbmon fps collapse: keyed {{#each}} instead of {{#each-in}}

### DIFF
--- a/frameworks/ember/dbmon-with-chat/app/templates/application.gts
+++ b/frameworks/ember/dbmon-with-chat/app/templates/application.gts
@@ -11,6 +11,12 @@ export default class Test extends Component {
   db = trackedMap<string, DBRow>();
   chats = trackedArray<ChatMessage>();
 
+  // rendered with a keyed {{#each}}: {{#each-in}} tears down and rebuilds
+  // every row on any map change (~4x fps difference on this bench)
+  get rows() {
+    return Array.from(this.db.values());
+  }
+
   start = () => {
     test.doit({
       handleDbUpdate: (eventData: DBUpdate) => {
@@ -39,10 +45,10 @@ export default class Test extends Component {
             <th colspan="5">elapsed times</th>
           </tr></thead>
         <tbody>
-          {{#each-in this.db as |id row|}}
+          {{#each this.rows key="dbname" as |row|}}
             <tr>
               <td class="dbname">
-                {{id}}
+                {{row.dbname}}
               </td>
               <td class="query-count">
                 <span class="{{row.lastSample.countClassName}}">
@@ -57,7 +63,7 @@ export default class Test extends Component {
                 </div>
               {{/each}}
             </tr>
-          {{/each-in}}
+          {{/each}}
         </tbody>
       </table>
 


### PR DESCRIPTION
## What happened

The ember dbmon bench collapsed from **~33 fps to ~7 fps** (4x CPU throttle, headless) across the last two days of upgrades. Bisection:

| configuration | fps (4x throttle) |
|---|---|
| ember 6.12.0-beta.1, old build stack | 37.8 |
| ember 6.12.0, new nvp build stack (#24) | 36.7 / 33.5 |
| ember 7.0.0-alpha.1, new stack | 13.1 |
| ember 7.0.0 / 7.1.0 / 7.3.0-alpha.5, new stack | ~7–10 |

So the build-stack migration (#24) is innocent (~within noise); the regression came with **ember-source 7.0** and shipped into this repo via the 7.1 (#24) and 7.3.0-alpha.5 (#29) bumps. Only dbmon regressed — it's the only bench using `{{#each-in}}`.

## Root cause

A `MutationObserver` on the table shows `{{#each-in this.db}}` **tears down and rebuilds every `<tr>` subtree on every map change** (~870 full row rebuilds/sec under the worker firehose — including all the hidden popover divs, so most of the frame goes to element creation + style recalc). It already did this on 6.12, but ember 7.0 made that teardown/rebuild path several times more expensive, which pushed dbmon off a cliff.

The other frameworks don't do this at all: react keys rows by `row.dbname`, solid/vue/svelte key their loops too, so their rows update in place. The ember app was structurally different — and unfairly slow — regardless of the 7.0 regression.

## Fix

Iterate the map's values with a keyed `{{#each this.rows key="dbname"}}` (matching every other framework's dbmon), keeping `trackedMap` and the granular `.set()` data flow unchanged:

- rows now update **in place**: element churn in the table drops from ~4,300 TR rebuilds/5s to **zero** (pure `characterData` updates)
- fps at 4x throttle on 7.3.0-alpha.5: **32.7–42.8** through the actual runner (was 7.2–7.6), i.e. fully recovered past the 6.12 baseline
- rendered output and data flow are unchanged (verified cell values still stream, DOM structure identical)

The `{{#each-in}}`-rebuilds-rows behavior (and its 7.0 cost multiplier) is an upstream ember/glimmer-vm issue worth filing separately — happy to write that up with the reduction from this investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)