### PR TITLE
Add playwright tests covering every framework x bench app; fix dbmon dev-mode 403s

### DIFF
--- a/.github/workflows/framework-apps.yml
+++ b/.github/workflows/framework-apps.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      # the apps' workers live in common/, which has no tsconfig of its
+      # own: vite/rolldown tsconfig discovery walks up to the repo root
+      # tsconfig.json, whose `extends` resolves from root node_modules
+      - run: pnpm install
       - run: pnpm install
         working-directory: tests
       - run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/framework-apps.yml
+++ b/.github/workflows/framework-apps.yml
@@ -1,0 +1,41 @@
+name: "Framework Apps"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+  group: ci-framework-apps-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Playwright (every framework x every bench)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install
+        working-directory: tests
+      - run: pnpm exec playwright install --with-deps chromium
+        working-directory: tests
+      # global-setup installs and builds all 25 apps (and common)
+      - run: pnpm test
+        working-directory: tests
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            tests/playwright-report/
+            tests/test-results/
+          retention-days: 7

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@
 *.md
 results/
 frameworks/
+tests/test-results/
+tests/playwright-report/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import { configs } from '@nullvoxpopuli/eslint-configs';
 
 export default defineConfig([
   ...configs.node(import.meta.dirname),
-  globalIgnores(['common', 'frameworks', 'results', 'node_modules']),
+  globalIgnores(['common', 'frameworks', 'results', 'tests', 'node_modules']),
   {
     files: ['src/**'],
     rules: {

--- a/frameworks/react/dbmon-with-chat/vite.config.ts
+++ b/frameworks/react/dbmon-with-chat/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // the linked `common` package lives outside this app's root; without this,
+  // its web workers 403 in dev (`/@fs/...` blocked by server.fs.allow)
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), '../../../common'],
+    },
+  },
   plugins: [react()],
 })

--- a/frameworks/solid/dbmon-with-chat/vite.config.ts
+++ b/frameworks/solid/dbmon-with-chat/vite.config.ts
@@ -1,6 +1,13 @@
-import { defineConfig } from 'vite'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import solid from 'vite-plugin-solid'
 
 export default defineConfig({
+  // the linked `common` package lives outside this app's root; without this,
+  // its web workers 403 in dev (`/@fs/...` blocked by server.fs.allow)
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), '../../../common'],
+    },
+  },
   plugins: [solid()],
 })

--- a/frameworks/svelte/dbmon-with-chat/vite.config.ts
+++ b/frameworks/svelte/dbmon-with-chat/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // the linked `common` package lives outside this app's root; without this,
+  // its web workers 403 in dev (`/@fs/...` blocked by server.fs.allow)
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), '../../../common'],
+    },
+  },
   plugins: [svelte()],
 })

--- a/frameworks/vue/dbmon-with-chat/vite.config.ts
+++ b/frameworks/vue/dbmon-with-chat/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // the linked `common` package lives outside this app's root; without this,
+  // its web workers 403 in dev (`/@fs/...` blocked by server.fs.allow)
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), '../../../common'],
+    },
+  },
   plugins: [vue()],
 })

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,6 @@
+# dependencies
+/node_modules/
+
+# playwright output
+/test-results/
+/playwright-report/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+# app-tests
+
+Playwright tests asserting that **every framework implementation of every
+bench actually works**, so PRs can't silently break an app.
+
+## What is covered
+
+- all 25 apps (5 frameworks x 5 benches), built and served like the bench
+  runner serves them
+  - benches that end (fan-out, one-item, ten-k, incrementing) self-verify
+    their DOM via `tryVerify` in `common` — the tests wait for the `:done`
+    performance mark and fail on any page error
+  - dbmon runs forever, so the tests assert both data streams render and
+    keep updating
+- `vite dev` for the 5 dbmon apps: dev serves the linked `common`
+  package's web workers via `/@fs`, which `server.fs.allow` can block —
+  a failure mode production builds do not have
+
+Workloads are shrunk via query params so the whole suite takes ~1 minute
+(after builds).
+
+## Running
+
+```bash
+cd tests
+pnpm install
+pnpm exec playwright install chromium
+
+pnpm test              # installs + builds all apps first
+SKIP_BUILD=1 pnpm test # reuse existing dists (fast local iteration)
+```

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { REPO_ROOT, FRAMEWORKS, BENCHES, appDir } from './helpers';
+
+const run = promisify(execFile);
+
+const CONCURRENCY = 4;
+
+/**
+ * Installs and builds every app so the specs can serve their dists.
+ *
+ * Skip with SKIP_BUILD=1 when iterating locally against already-built
+ * apps.
+ */
+export default async function globalSetup() {
+  if (process.env.SKIP_BUILD) {
+    console.log('SKIP_BUILD set: not installing/building apps');
+    return;
+  }
+
+  // apps link to common; its deps must exist first (pnpm does not
+  // install dependencies *of* linked packages)
+  await pnpm(join(REPO_ROOT, 'common'), ['install']);
+
+  const dirs: string[] = [];
+
+  for (const framework of FRAMEWORKS) {
+    for (const bench of BENCHES) {
+      dirs.push(appDir(framework, bench.app));
+    }
+  }
+
+  let failures: string[] = [];
+  let queue = dirs.entries();
+
+  async function worker() {
+    for (const [, dir] of queue) {
+      try {
+        await pnpm(dir, ['install']);
+        await pnpm(dir, ['build']);
+        console.log(`built ${dir.replace(REPO_ROOT, '')}`);
+      } catch (error) {
+        failures.push(
+          `${dir}: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+  if (failures.length > 0) {
+    throw new Error(`Some apps failed to build:\n${failures.join('\n')}`);
+  }
+
+  for (const dir of dirs) {
+    if (!existsSync(join(dir, 'dist', 'index.html'))) {
+      throw new Error(`${dir} has no dist/index.html after building`);
+    }
+  }
+}
+
+async function pnpm(cwd: string, args: string[]) {
+  await run('pnpm', args, { cwd, maxBuffer: 10 * 1024 * 1024 });
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,166 @@
+import { createServer, type Server } from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { join, extname, normalize } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+export const FRAMEWORKS = ['ember', 'react', 'solid', 'svelte', 'vue'] as const;
+
+export interface BenchSpec {
+  app: string;
+  /**
+   * Shrunk workloads so tests finish in seconds; the benches read these
+   * from the query string (see common/src/tests/*.js).
+   */
+  query: string;
+  /**
+   * 'done-mark': the bench self-verifies its DOM and calls tryVerify,
+   * which sets a `:done` performance mark on success and throws on
+   * failure (surfaced as a pageerror).
+   *
+   * 'continuous': the bench runs forever (dbmon); assert liveness
+   * structurally instead.
+   */
+  completion: 'done-mark' | 'continuous';
+  /** text that must be on the page once the bench completed */
+  expectText?: string;
+}
+
+export const BENCHES: BenchSpec[] = [
+  {
+    app: 'dbmon-with-chat',
+    query: '',
+    completion: 'continuous',
+  },
+  {
+    app: 'fan-out',
+    query: '?consumers=50&updates=500&burstSize=100',
+    completion: 'done-mark',
+    expectText: '[500]',
+  },
+  {
+    app: 'incrementing-render-effect',
+    query: '?updates=2000',
+    completion: 'done-mark',
+    expectText: '2000',
+  },
+  {
+    app: 'one-item-many-updates',
+    query: '?updates=300',
+    completion: 'done-mark',
+    expectText: '[299]',
+  },
+  {
+    app: 'ten-k-items-one-time',
+    query: '?items=200&updates=200',
+    completion: 'done-mark',
+    expectText: '[199]',
+  },
+];
+
+export function appDir(framework: string, app: string) {
+  return join(REPO_ROOT, 'frameworks', framework, app);
+}
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.wasm': 'application/wasm',
+};
+
+/**
+ * Serves a built app's dist folder the same way the bench runner does:
+ * plain static files, / -> /index.html.
+ */
+export async function serveDist(
+  distDir: string,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    const path = normalize(
+      decodeURIComponent((req.url ?? '/').split('?')[0] ?? '/'),
+    );
+    let file = join(distDir, path === '/' ? 'index.html' : path);
+
+    if (
+      !file.startsWith(distDir) ||
+      !existsSync(file) ||
+      statSync(file).isDirectory()
+    ) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': MIME[extname(file)] ?? 'application/octet-stream',
+    });
+    createReadStream(file).pipe(res);
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+
+  if (address === null || typeof address === 'string') {
+    throw new Error(`Could not determine port for static server of ${distDir}`);
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+/**
+ * Boots `vite dev` for an app and waits for it to answer. Dev mode has
+ * its own failure modes (e.g. server.fs.allow blocking the linked
+ * `common` package's web workers), so dbmon is tested here too.
+ */
+export async function startDevServer(
+  dir: string,
+  port: number,
+): Promise<{ url: string; stop: () => Promise<void> }> {
+  const child: ChildProcess = spawn(
+    'pnpm',
+    ['vite', '--port', String(port), '--strictPort'],
+    {
+      cwd: dir,
+      stdio: 'ignore',
+      detached: true,
+    },
+  );
+
+  const url = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + 60_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) break;
+    } catch {
+      // not up yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  return {
+    url,
+    stop: async () => {
+      if (child.pid) {
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+        } catch {
+          child.kill('SIGTERM');
+        }
+      }
+    },
+  };
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -128,39 +128,58 @@ export async function startDevServer(
   port: number,
 ): Promise<{ url: string; stop: () => Promise<void> }> {
   const child: ChildProcess = spawn(
-    'pnpm',
-    ['vite', '--port', String(port), '--strictPort'],
+    // the app's own vite binary: no package-manager indirection to differ
+    // between local and CI
+    join(dir, 'node_modules', '.bin', 'vite'),
+    // explicit IPv4 host: on CI runners `localhost` can resolve to ::1
+    // first, leaving 127.0.0.1 refusing connections
+    ['--port', String(port), '--strictPort', '--host', '127.0.0.1'],
     {
       cwd: dir,
-      stdio: 'ignore',
+      stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
     },
   );
+
+  let output = '';
+
+  child.stdout?.on('data', (chunk: Buffer) => (output += chunk.toString()));
+  child.stderr?.on('data', (chunk: Buffer) => (output += chunk.toString()));
+
+  let exited = false;
+
+  child.on('exit', () => (exited = true));
+
+  const stop = async () => {
+    if (child.pid) {
+      try {
+        process.kill(-child.pid, 'SIGTERM');
+      } catch {
+        child.kill('SIGTERM');
+      }
+    }
+  };
 
   const url = `http://127.0.0.1:${port}`;
   const deadline = Date.now() + 60_000;
 
   while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error(
+        `vite dev for ${dir} exited before listening:\n${output}`,
+      );
+    }
+
     try {
       const response = await fetch(url);
 
-      if (response.ok) break;
+      if (response.ok) return { url, stop };
     } catch {
       // not up yet
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
 
-  return {
-    url,
-    stop: async () => {
-      if (child.pid) {
-        try {
-          process.kill(-child.pid, 'SIGTERM');
-        } catch {
-          child.kill('SIGTERM');
-        }
-      }
-    },
-  };
+  await stop();
+  throw new Error(`vite dev for ${dir} never answered on ${url}:\n${output}`);
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "app-tests",
+  "private": true,
+  "type": "module",
+  "description": "Playwright tests that every framework implementation of every bench actually works",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.1",
+    "@types/node": "^24.13.2"
+  },
+  "engines": {
+    "node": ">= 24"
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  globalSetup: './global-setup.ts',
+
+  timeout: 90_000,
+  expect: { timeout: 45_000 },
+
+  /*
+   * The benches start via requestAnimationFrame + requestIdleCallback;
+   * too many busy pages at once starves idle callbacks in headless
+   * chromium and benches never start. Low parallelism + retries keeps
+   * this reliable.
+   */
+  workers: 2,
+  retries: 2,
+
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+
+  use: {
+    trace: 'retain-on-failure',
+  },
+});

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -1,0 +1,67 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+
+packages:
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+snapshots:
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  undici-types@7.18.2: {}

--- a/tests/specs/apps.spec.ts
+++ b/tests/specs/apps.spec.ts
@@ -1,0 +1,118 @@
+import { join } from 'node:path';
+
+import { test, expect, type Page } from '@playwright/test';
+
+import {
+  FRAMEWORKS,
+  BENCHES,
+  appDir,
+  serveDist,
+  startDevServer,
+  type BenchSpec,
+} from '../helpers';
+
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  return errors;
+}
+
+async function expectBenchCompletes(
+  page: Page,
+  bench: BenchSpec,
+  errors: string[],
+) {
+  if (bench.completion === 'done-mark') {
+    /*
+     * Every non-continuous bench self-verifies its rendered DOM
+     * (common/src/tests/utils.js tryVerify): a `:done` performance mark
+     * on success, a thrown error (-> pageerror) on failure.
+     */
+    await page.waitForFunction(
+      () => performance.getEntriesByName(':done', 'mark').length > 0,
+      undefined,
+      {
+        timeout: 60_000,
+      },
+    );
+
+    if (bench.expectText) {
+      await expect(page.locator('body')).toContainText(bench.expectText);
+    }
+  } else {
+    // dbmon runs forever: assert both data streams render and keep updating
+    await expect
+      .poll(() => page.locator('tbody tr').count(), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() => page.locator('.chat').count(), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    const sample = () => page.locator('tbody tr').first().innerText();
+    const before = await sample();
+
+    await expect.poll(sample, { timeout: 30_000 }).not.toBe(before);
+  }
+
+  expect(errors, 'no uncaught errors on the page').toEqual([]);
+}
+
+for (const framework of FRAMEWORKS) {
+  for (const bench of BENCHES) {
+    test(`${framework} / ${bench.app}`, async ({ page }) => {
+      const server = await serveDist(
+        join(appDir(framework, bench.app), 'dist'),
+      );
+
+      try {
+        const errors = collectPageErrors(page);
+
+        await page.goto(`${server.url}/${bench.query}`);
+        await expectBenchCompletes(page, bench, errors);
+      } finally {
+        await server.close();
+      }
+    });
+  }
+}
+
+/*
+ * dbmon is the only bench that loads raw assets (web workers, css) from
+ * the linked `common` package, which only vite dev serves via /@fs and
+ * can 403 (server.fs.allow). Prod builds bundle these, so only a dev
+ * server catches that class of breakage.
+ */
+const DEV_PORT_BASE = 4650;
+
+for (const [index, framework] of FRAMEWORKS.entries()) {
+  test(`${framework} / dbmon-with-chat (vite dev)`, async ({ page }) => {
+    const dev = await startDevServer(
+      appDir(framework, 'dbmon-with-chat'),
+      DEV_PORT_BASE + index,
+    );
+
+    try {
+      const errors = collectPageErrors(page);
+      const blocked: string[] = [];
+
+      page.on('response', (response) => {
+        // favicon is cosmetic; not every app declares one
+        if (response.status() >= 400 && !response.url().includes('favicon')) {
+          blocked.push(`${response.status()} ${response.url()}`);
+        }
+      });
+
+      await page.goto(dev.url);
+      await expectBenchCompletes(page, BENCHES[0]!, errors);
+
+      expect(
+        blocked,
+        'no 4xx/5xx responses (e.g. fs.allow blocking common)',
+      ).toEqual([]);
+    } finally {
+      await dev.stop();
+    }
+  });
+}


### PR DESCRIPTION
## The svelte dbmon breakage

Diagnosed: it (and react/vue/solid dbmon too) is broken **only in `vite dev`** — 0 rows, 0 chats. The web workers from the linked `common` package are served via `/@fs/…` and get **403'd by vite's `server.fs.allow`**, because `common` lives outside the app root:

```
403 /@fs/…/common/src/tests/dbmon/db-worker.js?worker
403 /@fs/…/common/src/tests/dbmon/chat-worker.js?worker
```

Production builds bundle the workers, so the built apps and the bench runner were unaffected — which is why this slipped through. The ember apps already carry the `fs.allow` fix; this PR adds the same `server.fs.allow` block to the four create-vite dbmon configs. All 5 dbmon apps verified working in dev after the fix (40 rows, 12 chats, live fps overlay).

## The test suite (`tests/`, sibling to `results/`)

30 playwright tests that iterate **every implementation**:

- **25 built apps** (5 frameworks x 5 benches), each served from `dist/` the way the runner serves them:
  - benches that end (fan-out, incrementing, one-item, ten-k) already self-verify their rendered DOM via `tryVerify` in common — success sets a `:done` performance mark, failure throws. Tests wait for the mark (with a final-content assertion on top) and fail on any pageerror, so the benches' own verification is the oracle.
  - dbmon runs forever, so tests assert both data streams render and keep updating.
- **5 `vite dev` tests for dbmon** — the only bench that loads raw assets from `common`, i.e. the exact class of breakage above. Verified: reverting the svelte `fs.allow` fix makes its dev test fail.

Workloads are shrunk via the benches' existing query params (`?updates=300` etc.), so the suite runs in **~35s** after builds (~1.2m including all installs+builds via `global-setup`). `SKIP_BUILD=1 pnpm test` reuses existing dists for local iteration. Low worker count + retries guard against the known headless requestIdleCallback-starvation flake.

## CI

New `framework-apps.yml` workflow runs the suite on every PR (playwright report uploaded on failure). As a bonus, the build step also enforces the react/vue/solid `tsc`/`vue-tsc` type-checks on every PR, since their `build` scripts include them.

Also: `tests/` added to root eslint ignores (standalone project) and playwright artifacts to `.prettierignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)