### PR TITLE
Add raw / score / times-best toggle to the results table page

### DIFF
--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -18,6 +18,8 @@ export default class Results extends Route<Model> {
 
   queryParams = {
     q: { refreshModel: true },
+    // display mode for the tables page (raw | linear | log); no model impact
+    mode: {},
   };
 
   beforeModel(transition: Transition) {

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -163,3 +163,23 @@ table {
     mix-blend-mode: difference;
   }
 }
+
+.value-mode {
+  display: inline-flex;
+  gap: 1rem;
+  border: 1px solid lightgray;
+  padding: 0.25rem 0.75rem;
+
+  legend {
+    font-size: 0.8rem;
+  }
+
+  label {
+    cursor: pointer;
+
+    .units {
+      font-size: 0.8rem;
+      color: gray;
+    }
+  }
+}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -36,6 +36,16 @@ function colorFor(
 type ValueMode = "raw" | "linear" | "times";
 
 /**
+ * The ?mode= query param, wherever a component needs it.
+ * router.currentRoute is tracked, so reads stay live across transitions.
+ */
+function modeFrom(router: RouterService): ValueMode {
+  const mode = router.currentRoute?.queryParams["mode"];
+
+  return mode === "linear" || mode === "times" ? mode : "raw";
+}
+
+/**
  * The same normalization the cell colors use, as a displayable value.
  */
 function scoreFor(speed: number | undefined, min: number | undefined, max: number | undefined) {
@@ -90,8 +100,9 @@ class TableRow extends Component<{
   file: ResultSet;
   benchInfo: BenchmarkInfo;
   frameworkNames: string[];
-  mode: ValueMode;
 }> {
+  @service declare router: RouterService;
+
   declare speeds: Record<string, number | undefined>;
   declare colors: Record<string, string | undefined>;
   max = -Infinity;
@@ -103,7 +114,6 @@ class TableRow extends Component<{
       file: ResultSet;
       benchInfo: BenchmarkInfo;
       frameworkNames: string[];
-      mode: ValueMode;
     },
   ) {
     super(owner, args);
@@ -131,7 +141,7 @@ class TableRow extends Component<{
     const speed = this.speeds[framework];
     const bestIsMax = this.args.benchInfo.whatsBetter === "bigger";
 
-    switch (this.args.mode) {
+    switch (modeFrom(this.router)) {
       case "linear":
         return scoreFor(speed, this.min, this.max);
       case "times": {
@@ -168,8 +178,9 @@ class TableRow extends Component<{
 class Table extends Component<{
   benches: BenchmarkInfo[];
   file: ResultSet;
-  mode: ValueMode;
 }> {
+  @service declare router: RouterService;
+
   shouldShowTotals = false;
   totals: Record<string, number> = {};
 
@@ -178,7 +189,6 @@ class Table extends Component<{
     args: {
       benches: BenchmarkInfo[];
       file: ResultSet;
-      mode: ValueMode;
     },
   ) {
     super(owner, args);
@@ -222,7 +232,7 @@ class Table extends Component<{
   totalValue = (framework: string) => {
     const total = this.totals[framework];
 
-    switch (this.args.mode) {
+    switch (modeFrom(this.router)) {
       case "linear":
         return scoreFor(total, this.totals.min, this.totals.max);
       case "times": {
@@ -280,12 +290,7 @@ class Table extends Component<{
       </thead>
       <tbody>
         {{#each @benches as |bench|}}
-          <TableRow
-            @file={{@file}}
-            @benchInfo={{bench}}
-            @frameworkNames={{this.frameworkNames}}
-            @mode={{@mode}}
-          />
+          <TableRow @file={{@file}} @benchInfo={{bench}} @frameworkNames={{this.frameworkNames}} />
         {{/each}}
       </tbody>
 
@@ -316,9 +321,7 @@ export default class ResultsTables extends Component<{
   @service declare router: RouterService;
 
   get mode(): ValueMode {
-    const mode = this.router.currentRoute?.queryParams["mode"];
-
-    return mode === "linear" || mode === "times" ? mode : "raw";
+    return modeFrom(this.router);
   }
 
   setMode = (mode: ValueMode) => {
@@ -385,7 +388,7 @@ export default class ResultsTables extends Component<{
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>
 
-      <Table @benches={{this.higherBenches}} @file={{this.file}} @mode={{this.mode}} />
+      <Table @benches={{this.higherBenches}} @file={{this.file}} />
       <br />
       <br />
       <br />
@@ -394,7 +397,7 @@ export default class ResultsTables extends Component<{
     {{#if this.lowerBenches.length}}
       <h2>lower is better</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} @mode={{this.mode}} />
+      <Table @benches={{this.lowerBenches}} @file={{this.file}} />
       <br />
       <br />
       <br />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { cached } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { warn } from "@ember/debug";
 import { get } from "@ember/helper";
 
@@ -31,10 +31,21 @@ function colorFor(
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
 
+/**
+ * The same normalization the cell colors use, as a displayable value.
+ */
+function scoreFor(speed: number | undefined, min: number | undefined, max: number | undefined) {
+  if (speed === undefined || min === undefined || max === undefined) return;
+  if (max === min) return (1).toFixed(2);
+
+  return ((speed - min) / (max - min)).toFixed(2);
+}
+
 class TableRow extends Component<{
   file: ResultSet;
   benchInfo: BenchmarkInfo;
   frameworkNames: string[];
+  showScores: boolean;
 }> {
   declare speeds: Record<string, number | undefined>;
   declare colors: Record<string, string | undefined>;
@@ -47,6 +58,7 @@ class TableRow extends Component<{
       file: ResultSet;
       benchInfo: BenchmarkInfo;
       frameworkNames: string[];
+      showScores: boolean;
     },
   ) {
     super(owner, args);
@@ -79,6 +91,10 @@ class TableRow extends Component<{
     }
   }
 
+  score = (framework: string) => {
+    return scoreFor(this.speeds[framework], this.min, this.max);
+  };
+
   <template>
     <tr>
       <td class="benchmark-name">
@@ -91,10 +107,9 @@ class TableRow extends Component<{
       </td>
 
       {{#each @frameworkNames as |framework|}}
-        <td style="background: {{get this.colors framework}};"><span class="value">{{get
-              this.speeds
-              framework
-            }}</span></td>
+        <td style="background: {{get this.colors framework}};"><span class="value">{{#if
+              @showScores
+            }}{{this.score framework}}{{else}}{{get this.speeds framework}}{{/if}}</span></td>
       {{/each}}
     </tr>
   </template>
@@ -103,6 +118,7 @@ class TableRow extends Component<{
 class Table extends Component<{
   benches: BenchmarkInfo[];
   file: ResultSet;
+  showScores: boolean;
 }> {
   shouldShowTotals = false;
   totals: Record<string, number> = {};
@@ -112,6 +128,7 @@ class Table extends Component<{
     args: {
       benches: BenchmarkInfo[];
       file: ResultSet;
+      showScores: boolean;
     },
   ) {
     super(owner, args);
@@ -152,6 +169,10 @@ class Table extends Component<{
     return this.args.file.selections.frameworks;
   }
 
+  totalScore = (framework: string) => {
+    return scoreFor(this.totals[framework], this.totals.min, this.totals.max);
+  };
+
   versionFor = (framework: string) => {
     /**
      * Because each bench mark is a different app, it is possible the versions diverge
@@ -190,7 +211,12 @@ class Table extends Component<{
       </thead>
       <tbody>
         {{#each @benches as |bench|}}
-          <TableRow @file={{@file}} @benchInfo={{bench}} @frameworkNames={{this.frameworkNames}} />
+          <TableRow
+            @file={{@file}}
+            @benchInfo={{bench}}
+            @frameworkNames={{this.frameworkNames}}
+            @showScores={{@showScores}}
+          />
         {{/each}}
       </tbody>
 
@@ -205,7 +231,10 @@ class Table extends Component<{
                   this.totals.max
                 }}"
               >
-                <span class="value">{{get this.totals framework}}</span>
+                <span class="value">{{#if @showScores}}{{this.totalScore framework}}{{else}}{{get
+                      this.totals
+                      framework
+                    }}{{/if}}</span>
               </td>
             {{/each}}
           </tr>
@@ -218,6 +247,11 @@ class Table extends Component<{
 export default class ResultsTables extends Component<{
   model: Model;
 }> {
+  @tracked showScores = false;
+
+  showRawValues = () => (this.showScores = false);
+  showScoreValues = () => (this.showScores = true);
+
   get file() {
     return this.args.model.data;
   }
@@ -240,10 +274,33 @@ export default class ResultsTables extends Component<{
   }
 
   <template>
+    <fieldset class="value-mode">
+      <legend>values</legend>
+      <label>
+        <input
+          type="radio"
+          name="value-mode"
+          checked={{unless this.showScores true}}
+          {{on "change" this.showRawValues}}
+        />
+        raw
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="value-mode"
+          checked={{this.showScores}}
+          {{on "change" this.showScoreValues}}
+        />
+        score
+        <span class="units">(normalized 0 to 1)</span>
+      </label>
+    </fieldset>
+
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>
 
-      <Table @benches={{this.higherBenches}} @file={{this.file}} />
+      <Table @benches={{this.higherBenches}} @file={{this.file}} @showScores={{this.showScores}} />
       <br />
       <br />
       <br />
@@ -252,7 +309,7 @@ export default class ResultsTables extends Component<{
     {{#if this.lowerBenches.length}}
       <h2>lower is better</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} />
+      <Table @benches={{this.lowerBenches}} @file={{this.file}} @showScores={{this.showScores}} />
       <br />
       <br />
       <br />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -33,7 +33,7 @@ function colorFor(
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
 
-type ValueMode = "raw" | "linear" | "log";
+type ValueMode = "raw" | "linear" | "log" | "ranking";
 
 /**
  * The same normalization the cell colors use, as a displayable value.
@@ -72,6 +72,60 @@ function logScoreFor(
   return (bestIsMax ? 1 - warped : warped).toFixed(2);
 }
 
+const ORDINAL_RULES = new Intl.PluralRules("en", { type: "ordinal" });
+const ORDINAL_SUFFIXES: Record<string, string> = { one: "st", two: "nd", few: "rd", other: "th" };
+
+function ordinal(rank: number) {
+  return `${rank}${ORDINAL_SUFFIXES[ORDINAL_RULES.select(rank)]}`;
+}
+
+/**
+ * Competition ranking: 1 + the number of strictly better values, so
+ * ties share a rank.
+ */
+function rankFor(
+  values: Record<string, number | undefined>,
+  names: string[],
+  name: string,
+  bestIsMax: boolean,
+) {
+  const value = values[name];
+
+  if (value === undefined) return;
+
+  let better = 0;
+
+  for (const other of names) {
+    const otherValue = values[other];
+
+    if (otherValue === undefined) continue;
+    if (bestIsMax ? otherValue > value : otherValue < value) better++;
+  }
+
+  return 1 + better;
+}
+
+function speedsFor(file: ResultSet, benchInfo: BenchmarkInfo, frameworkNames: string[]) {
+  const speeds: Record<string, number | undefined> = {};
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const framework of frameworkNames) {
+    const test = file.results[framework]?.[benchInfo.name];
+
+    if (!test) continue;
+
+    const time = timeFromMarks(test.times, benchInfo.measure);
+
+    speeds[framework] = time;
+
+    if (time > max) max = time;
+    if (time < min) min = time;
+  }
+
+  return { speeds, min, max };
+}
+
 class TableRow extends Component<{
   file: ResultSet;
   benchInfo: BenchmarkInfo;
@@ -94,21 +148,12 @@ class TableRow extends Component<{
   ) {
     super(owner, args);
 
-    this.speeds = {};
+    const { speeds, min, max } = speedsFor(args.file, args.benchInfo, args.frameworkNames);
+
+    this.speeds = speeds;
+    this.min = min;
+    this.max = max;
     this.colors = {};
-
-    for (const framework of args.frameworkNames) {
-      const test = args.file.results[framework]?.[args.benchInfo.name];
-
-      if (!test) continue;
-
-      const time = timeFromMarks(test.times, this.args.benchInfo.measure);
-
-      this.speeds[framework] = time;
-
-      if (time > this.max) this.max = time;
-      if (time < this.min) this.min = time;
-    }
 
     for (const framework of args.frameworkNames) {
       const time = this.speeds[framework];
@@ -124,12 +169,19 @@ class TableRow extends Component<{
 
   value = (framework: string) => {
     const speed = this.speeds[framework];
+    const bestIsMax = this.args.benchInfo.whatsBetter === "bigger";
 
     switch (this.args.mode) {
       case "linear":
         return scoreFor(speed, this.min, this.max);
       case "log":
-        return logScoreFor(speed, this.min, this.max, this.args.benchInfo.whatsBetter === "bigger");
+        return logScoreFor(speed, this.min, this.max, bestIsMax);
+      case "ranking": {
+        const rank = rankFor(this.speeds, this.args.frameworkNames, framework, bestIsMax);
+
+        return rank === undefined ? undefined : ordinal(rank);
+      }
+
       default:
         return speed;
     }
@@ -209,6 +261,33 @@ class Table extends Component<{
     return this.args.file.selections.frameworks;
   }
 
+  /**
+   * Each framework's ranks across this table's benches, summed.
+   */
+  @cached
+  get rankTotals(): Record<string, number | undefined> {
+    const sums: Record<string, number | undefined> = {};
+
+    for (const bench of this.args.benches) {
+      const { speeds } = speedsFor(this.args.file, bench, this.frameworkNames);
+
+      for (const framework of this.frameworkNames) {
+        const rank = rankFor(
+          speeds,
+          this.frameworkNames,
+          framework,
+          bench.whatsBetter === "bigger",
+        );
+
+        if (rank === undefined) continue;
+
+        sums[framework] = (sums[framework] ?? 0) + rank;
+      }
+    }
+
+    return sums;
+  }
+
   totalValue = (framework: string) => {
     const total = this.totals[framework];
 
@@ -222,6 +301,13 @@ class Table extends Component<{
           this.totals.max,
           this.args.benches[0]?.whatsBetter === "bigger",
         );
+      case "ranking": {
+        // lowest rank sum is the overall winner
+        const rank = rankFor(this.rankTotals, this.frameworkNames, framework, false);
+
+        return rank === undefined ? undefined : ordinal(rank);
+      }
+
       default:
         return total;
     }
@@ -303,7 +389,7 @@ export default class ResultsTables extends Component<{
   get mode(): ValueMode {
     const mode = this.router.currentRoute?.queryParams["mode"];
 
-    return mode === "linear" || mode === "log" ? mode : "raw";
+    return mode === "linear" || mode === "log" || mode === "ranking" ? mode : "raw";
   }
 
   setMode = (mode: ValueMode) => {
@@ -364,6 +450,16 @@ export default class ResultsTables extends Component<{
         />
         log score
         <span class="units">(more variance near best)</span>
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="value-mode"
+          checked={{this.isMode "ranking"}}
+          {{on "change" (fn this.setMode "ranking")}}
+        />
+        ranking
+        <span class="units">(1st is best)</span>
       </label>
     </fieldset>
 

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -31,6 +31,8 @@ function colorFor(
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
 
+type ValueMode = "raw" | "linear" | "log";
+
 /**
  * The same normalization the cell colors use, as a displayable value.
  */
@@ -41,11 +43,38 @@ function scoreFor(speed: number | undefined, min: number | undefined, max: numbe
   return ((speed - min) / (max - min)).toFixed(2);
 }
 
+/**
+ * One decade of spread: distances from best map like log10(1 + 9u).
+ */
+const LOG_SCALE = 9;
+
+/**
+ * Like scoreFor, but warped so the steep part of the log sits at the
+ * "best" end: frameworks close to the best spread apart, differences
+ * among the slowest compress. Orientation matches the linear score
+ * (and the colors): best is 1 when bigger is better, 0 otherwise.
+ */
+function logScoreFor(
+  speed: number | undefined,
+  min: number | undefined,
+  max: number | undefined,
+  bestIsMax: boolean,
+) {
+  if (speed === undefined || min === undefined || max === undefined) return;
+  if (max === min) return (bestIsMax ? 1 : 0).toFixed(2);
+
+  const linear = (speed - min) / (max - min);
+  const distanceFromBest = bestIsMax ? 1 - linear : linear;
+  const warped = Math.log1p(LOG_SCALE * distanceFromBest) / Math.log1p(LOG_SCALE);
+
+  return (bestIsMax ? 1 - warped : warped).toFixed(2);
+}
+
 class TableRow extends Component<{
   file: ResultSet;
   benchInfo: BenchmarkInfo;
   frameworkNames: string[];
-  showScores: boolean;
+  mode: ValueMode;
 }> {
   declare speeds: Record<string, number | undefined>;
   declare colors: Record<string, string | undefined>;
@@ -58,7 +87,7 @@ class TableRow extends Component<{
       file: ResultSet;
       benchInfo: BenchmarkInfo;
       frameworkNames: string[];
-      showScores: boolean;
+      mode: ValueMode;
     },
   ) {
     super(owner, args);
@@ -91,8 +120,17 @@ class TableRow extends Component<{
     }
   }
 
-  score = (framework: string) => {
-    return scoreFor(this.speeds[framework], this.min, this.max);
+  value = (framework: string) => {
+    const speed = this.speeds[framework];
+
+    switch (this.args.mode) {
+      case "linear":
+        return scoreFor(speed, this.min, this.max);
+      case "log":
+        return logScoreFor(speed, this.min, this.max, this.args.benchInfo.whatsBetter === "bigger");
+      default:
+        return speed;
+    }
   };
 
   <template>
@@ -107,9 +145,9 @@ class TableRow extends Component<{
       </td>
 
       {{#each @frameworkNames as |framework|}}
-        <td style="background: {{get this.colors framework}};"><span class="value">{{#if
-              @showScores
-            }}{{this.score framework}}{{else}}{{get this.speeds framework}}{{/if}}</span></td>
+        <td style="background: {{get this.colors framework}};"><span class="value">{{this.value
+              framework
+            }}</span></td>
       {{/each}}
     </tr>
   </template>
@@ -118,7 +156,7 @@ class TableRow extends Component<{
 class Table extends Component<{
   benches: BenchmarkInfo[];
   file: ResultSet;
-  showScores: boolean;
+  mode: ValueMode;
 }> {
   shouldShowTotals = false;
   totals: Record<string, number> = {};
@@ -128,7 +166,7 @@ class Table extends Component<{
     args: {
       benches: BenchmarkInfo[];
       file: ResultSet;
-      showScores: boolean;
+      mode: ValueMode;
     },
   ) {
     super(owner, args);
@@ -169,8 +207,22 @@ class Table extends Component<{
     return this.args.file.selections.frameworks;
   }
 
-  totalScore = (framework: string) => {
-    return scoreFor(this.totals[framework], this.totals.min, this.totals.max);
+  totalValue = (framework: string) => {
+    const total = this.totals[framework];
+
+    switch (this.args.mode) {
+      case "linear":
+        return scoreFor(total, this.totals.min, this.totals.max);
+      case "log":
+        return logScoreFor(
+          total,
+          this.totals.min,
+          this.totals.max,
+          this.args.benches[0]?.whatsBetter === "bigger",
+        );
+      default:
+        return total;
+    }
   };
 
   versionFor = (framework: string) => {
@@ -215,7 +267,7 @@ class Table extends Component<{
             @file={{@file}}
             @benchInfo={{bench}}
             @frameworkNames={{this.frameworkNames}}
-            @showScores={{@showScores}}
+            @mode={{@mode}}
           />
         {{/each}}
       </tbody>
@@ -231,10 +283,7 @@ class Table extends Component<{
                   this.totals.max
                 }}"
               >
-                <span class="value">{{#if @showScores}}{{this.totalScore framework}}{{else}}{{get
-                      this.totals
-                      framework
-                    }}{{/if}}</span>
+                <span class="value">{{this.totalValue framework}}</span>
               </td>
             {{/each}}
           </tr>
@@ -247,10 +296,10 @@ class Table extends Component<{
 export default class ResultsTables extends Component<{
   model: Model;
 }> {
-  @tracked showScores = false;
+  @tracked mode: ValueMode = "raw";
 
-  showRawValues = () => (this.showScores = false);
-  showScoreValues = () => (this.showScores = true);
+  setMode = (mode: ValueMode) => (this.mode = mode);
+  isMode = (mode: ValueMode) => this.mode === mode;
 
   get file() {
     return this.args.model.data;
@@ -280,8 +329,8 @@ export default class ResultsTables extends Component<{
         <input
           type="radio"
           name="value-mode"
-          checked={{unless this.showScores true}}
-          {{on "change" this.showRawValues}}
+          checked={{this.isMode "raw"}}
+          {{on "change" (fn this.setMode "raw")}}
         />
         raw
       </label>
@@ -289,18 +338,28 @@ export default class ResultsTables extends Component<{
         <input
           type="radio"
           name="value-mode"
-          checked={{this.showScores}}
-          {{on "change" this.showScoreValues}}
+          checked={{this.isMode "linear"}}
+          {{on "change" (fn this.setMode "linear")}}
         />
         score
         <span class="units">(normalized 0 to 1)</span>
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="value-mode"
+          checked={{this.isMode "log"}}
+          {{on "change" (fn this.setMode "log")}}
+        />
+        log score
+        <span class="units">(more variance near best)</span>
       </label>
     </fieldset>
 
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>
 
-      <Table @benches={{this.higherBenches}} @file={{this.file}} @showScores={{this.showScores}} />
+      <Table @benches={{this.higherBenches}} @file={{this.file}} @mode={{this.mode}} />
       <br />
       <br />
       <br />
@@ -309,7 +368,7 @@ export default class ResultsTables extends Component<{
     {{#if this.lowerBenches.length}}
       <h2>lower is better</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} @showScores={{this.showScores}} />
+      <Table @benches={{this.lowerBenches}} @file={{this.file}} @mode={{this.mode}} />
       <br />
       <br />
       <br />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -1,7 +1,8 @@
 import Component from "@glimmer/component";
-import { cached, tracked } from "@glimmer/tracking";
+import { cached } from "@glimmer/tracking";
 import { warn } from "@ember/debug";
 import { get } from "@ember/helper";
+import { service } from "@ember/service";
 
 import { interpolate } from "culori";
 
@@ -9,6 +10,7 @@ import { FrameworkInfo } from "#components/framework-info.gts";
 import { round, timeFromMarks } from "#utils";
 
 import type Owner from "@ember/owner";
+import type RouterService from "@ember/routing/router-service";
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
 
@@ -296,9 +298,18 @@ class Table extends Component<{
 export default class ResultsTables extends Component<{
   model: Model;
 }> {
-  @tracked mode: ValueMode = "raw";
+  @service declare router: RouterService;
 
-  setMode = (mode: ValueMode) => (this.mode = mode);
+  get mode(): ValueMode {
+    const mode = this.router.currentRoute?.queryParams["mode"];
+
+    return mode === "linear" || mode === "log" ? mode : "raw";
+  }
+
+  setMode = (mode: ValueMode) => {
+    this.router.transitionTo({ queryParams: { mode } });
+  };
+
   isMode = (mode: ValueMode) => this.mode === mode;
 
   get file() {

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -33,7 +33,7 @@ function colorFor(
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
 
-type ValueMode = "raw" | "linear" | "log" | "ranking" | "times";
+type ValueMode = "raw" | "linear" | "times";
 
 /**
  * The same normalization the cell colors use, as a displayable value.
@@ -43,66 +43,6 @@ function scoreFor(speed: number | undefined, min: number | undefined, max: numbe
   if (max === min) return (1).toFixed(2);
 
   return ((speed - min) / (max - min)).toFixed(2);
-}
-
-/**
- * One decade of spread: distances from best map like log10(1 + 9u).
- */
-const LOG_SCALE = 9;
-
-/**
- * Like scoreFor, but warped so the steep part of the log sits at the
- * "best" end: frameworks close to the best spread apart, differences
- * among the slowest compress. Orientation matches the linear score
- * (and the colors): best is 1 when bigger is better, 0 otherwise.
- */
-function logScoreFor(
-  speed: number | undefined,
-  min: number | undefined,
-  max: number | undefined,
-  bestIsMax: boolean,
-) {
-  if (speed === undefined || min === undefined || max === undefined) return;
-  if (max === min) return (bestIsMax ? 1 : 0).toFixed(2);
-
-  const linear = (speed - min) / (max - min);
-  const distanceFromBest = bestIsMax ? 1 - linear : linear;
-  const warped = Math.log1p(LOG_SCALE * distanceFromBest) / Math.log1p(LOG_SCALE);
-
-  return (bestIsMax ? 1 - warped : warped).toFixed(2);
-}
-
-const ORDINAL_RULES = new Intl.PluralRules("en", { type: "ordinal" });
-const ORDINAL_SUFFIXES: Record<string, string> = { one: "st", two: "nd", few: "rd", other: "th" };
-
-function ordinal(rank: number) {
-  return `${rank}${ORDINAL_SUFFIXES[ORDINAL_RULES.select(rank)]}`;
-}
-
-/**
- * Competition ranking: 1 + the number of strictly better values, so
- * ties share a rank.
- */
-function rankFor(
-  values: Record<string, number | undefined>,
-  names: string[],
-  name: string,
-  bestIsMax: boolean,
-) {
-  const value = values[name];
-
-  if (value === undefined) return;
-
-  let better = 0;
-
-  for (const other of names) {
-    const otherValue = values[other];
-
-    if (otherValue === undefined) continue;
-    if (bestIsMax ? otherValue > value : otherValue < value) better++;
-  }
-
-  return 1 + better;
 }
 
 /**
@@ -194,14 +134,6 @@ class TableRow extends Component<{
     switch (this.args.mode) {
       case "linear":
         return scoreFor(speed, this.min, this.max);
-      case "log":
-        return logScoreFor(speed, this.min, this.max, bestIsMax);
-      case "ranking": {
-        const rank = rankFor(this.speeds, this.args.frameworkNames, framework, bestIsMax);
-
-        return rank === undefined ? undefined : ordinal(rank);
-      }
-
       case "times": {
         const ratio = timesBestFor(speed, this.min, this.max, bestIsMax);
 
@@ -287,94 +219,22 @@ class Table extends Component<{
     return this.args.file.selections.frameworks;
   }
 
-  /**
-   * Each framework's ranks across this table's benches, summed.
-   */
-  @cached
-  get rankTotals(): Record<string, number | undefined> {
-    const sums: Record<string, number | undefined> = {};
-
-    for (const bench of this.args.benches) {
-      const { speeds } = speedsFor(this.args.file, bench, this.frameworkNames);
-
-      for (const framework of this.frameworkNames) {
-        const rank = rankFor(
-          speeds,
-          this.frameworkNames,
-          framework,
-          bench.whatsBetter === "bigger",
-        );
-
-        if (rank === undefined) continue;
-
-        sums[framework] = (sums[framework] ?? 0) + rank;
-      }
-    }
-
-    return sums;
-  }
-
-  /**
-   * Weighted geometric mean of each framework's times-best multipliers
-   * across this table's benches: exp(sum(w * ln(ratio)) / sum(w)).
-   * Every bench currently weighs 1 (BenchmarkInfo.weight is the seam).
-   */
-  @cached
-  get timesTotals(): Record<string, number | undefined> {
-    const logSums: Record<string, number> = {};
-    const weightSums: Record<string, number> = {};
-
-    for (const bench of this.args.benches) {
-      const weight = bench.weight ?? 1;
-      const { speeds, min, max } = speedsFor(this.args.file, bench, this.frameworkNames);
-
-      for (const framework of this.frameworkNames) {
-        const ratio = timesBestFor(speeds[framework], min, max, bench.whatsBetter === "bigger");
-
-        if (ratio === undefined) continue;
-
-        logSums[framework] = (logSums[framework] ?? 0) + weight * Math.log(ratio);
-        weightSums[framework] = (weightSums[framework] ?? 0) + weight;
-      }
-    }
-
-    const means: Record<string, number | undefined> = {};
-
-    for (const framework of this.frameworkNames) {
-      const weightSum = weightSums[framework];
-
-      if (!weightSum) continue;
-
-      means[framework] = Math.exp((logSums[framework] ?? 0) / weightSum);
-    }
-
-    return means;
-  }
-
   totalValue = (framework: string) => {
     const total = this.totals[framework];
 
     switch (this.args.mode) {
       case "linear":
         return scoreFor(total, this.totals.min, this.totals.max);
-      case "log":
-        return logScoreFor(
+      case "times": {
+        // times-best of the raw totals, so the best column reads 1x
+        const ratio = timesBestFor(
           total,
           this.totals.min,
           this.totals.max,
           this.args.benches[0]?.whatsBetter === "bigger",
         );
-      case "ranking": {
-        // lowest rank sum is the overall winner
-        const rank = rankFor(this.rankTotals, this.frameworkNames, framework, false);
 
-        return rank === undefined ? undefined : ordinal(rank);
-      }
-
-      case "times": {
-        const mean = this.timesTotals[framework];
-
-        return mean === undefined ? undefined : formatTimes(mean);
+        return ratio === undefined ? undefined : formatTimes(ratio);
       }
 
       default:
@@ -458,9 +318,7 @@ export default class ResultsTables extends Component<{
   get mode(): ValueMode {
     const mode = this.router.currentRoute?.queryParams["mode"];
 
-    return mode === "linear" || mode === "log" || mode === "ranking" || mode === "times"
-      ? mode
-      : "raw";
+    return mode === "linear" || mode === "times" ? mode : "raw";
   }
 
   setMode = (mode: ValueMode) => {
@@ -511,26 +369,6 @@ export default class ResultsTables extends Component<{
         />
         score
         <span class="units">(normalized 0 to 1)</span>
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="value-mode"
-          checked={{this.isMode "log"}}
-          {{on "change" (fn this.setMode "log")}}
-        />
-        log score
-        <span class="units">(more variance near best)</span>
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="value-mode"
-          checked={{this.isMode "ranking"}}
-          {{on "change" (fn this.setMode "ranking")}}
-        />
-        ranking
-        <span class="units">(1st is best)</span>
       </label>
       <label>
         <input

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -33,7 +33,7 @@ function colorFor(
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
 
-type ValueMode = "raw" | "linear" | "log" | "ranking";
+type ValueMode = "raw" | "linear" | "log" | "ranking" | "times";
 
 /**
  * The same normalization the cell colors use, as a displayable value.
@@ -103,6 +103,26 @@ function rankFor(
   }
 
   return 1 + better;
+}
+
+/**
+ * How many times worse than the row's best this value is: 1 for the
+ * best, 1.1 for 10% worse, etc. Always >= 1 regardless of direction.
+ */
+function timesBestFor(
+  speed: number | undefined,
+  min: number | undefined,
+  max: number | undefined,
+  bestIsMax: boolean,
+) {
+  if (speed === undefined || min === undefined || max === undefined) return;
+  if (speed <= 0 || min <= 0) return;
+
+  return bestIsMax ? max / speed : speed / min;
+}
+
+function formatTimes(ratio: number) {
+  return `${Math.round(ratio * 100) / 100}x`;
 }
 
 function speedsFor(file: ResultSet, benchInfo: BenchmarkInfo, frameworkNames: string[]) {
@@ -180,6 +200,12 @@ class TableRow extends Component<{
         const rank = rankFor(this.speeds, this.args.frameworkNames, framework, bestIsMax);
 
         return rank === undefined ? undefined : ordinal(rank);
+      }
+
+      case "times": {
+        const ratio = timesBestFor(speed, this.min, this.max, bestIsMax);
+
+        return ratio === undefined ? undefined : formatTimes(ratio);
       }
 
       default:
@@ -288,6 +314,43 @@ class Table extends Component<{
     return sums;
   }
 
+  /**
+   * Weighted geometric mean of each framework's times-best multipliers
+   * across this table's benches: exp(sum(w * ln(ratio)) / sum(w)).
+   * Every bench currently weighs 1 (BenchmarkInfo.weight is the seam).
+   */
+  @cached
+  get timesTotals(): Record<string, number | undefined> {
+    const logSums: Record<string, number> = {};
+    const weightSums: Record<string, number> = {};
+
+    for (const bench of this.args.benches) {
+      const weight = bench.weight ?? 1;
+      const { speeds, min, max } = speedsFor(this.args.file, bench, this.frameworkNames);
+
+      for (const framework of this.frameworkNames) {
+        const ratio = timesBestFor(speeds[framework], min, max, bench.whatsBetter === "bigger");
+
+        if (ratio === undefined) continue;
+
+        logSums[framework] = (logSums[framework] ?? 0) + weight * Math.log(ratio);
+        weightSums[framework] = (weightSums[framework] ?? 0) + weight;
+      }
+    }
+
+    const means: Record<string, number | undefined> = {};
+
+    for (const framework of this.frameworkNames) {
+      const weightSum = weightSums[framework];
+
+      if (!weightSum) continue;
+
+      means[framework] = Math.exp((logSums[framework] ?? 0) / weightSum);
+    }
+
+    return means;
+  }
+
   totalValue = (framework: string) => {
     const total = this.totals[framework];
 
@@ -306,6 +369,12 @@ class Table extends Component<{
         const rank = rankFor(this.rankTotals, this.frameworkNames, framework, false);
 
         return rank === undefined ? undefined : ordinal(rank);
+      }
+
+      case "times": {
+        const mean = this.timesTotals[framework];
+
+        return mean === undefined ? undefined : formatTimes(mean);
       }
 
       default:
@@ -389,7 +458,9 @@ export default class ResultsTables extends Component<{
   get mode(): ValueMode {
     const mode = this.router.currentRoute?.queryParams["mode"];
 
-    return mode === "linear" || mode === "log" || mode === "ranking" ? mode : "raw";
+    return mode === "linear" || mode === "log" || mode === "ranking" || mode === "times"
+      ? mode
+      : "raw";
   }
 
   setMode = (mode: ValueMode) => {
@@ -460,6 +531,16 @@ export default class ResultsTables extends Component<{
         />
         ranking
         <span class="units">(1st is best)</span>
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="value-mode"
+          checked={{this.isMode "times"}}
+          {{on "change" (fn this.setMode "times")}}
+        />
+        times best
+        <span class="units">(1x is best)</span>
       </label>
     </fieldset>
 

--- a/results/app/types.ts
+++ b/results/app/types.ts
@@ -32,6 +32,11 @@ export interface BenchmarkInfo {
   measure?: string;
   whatsBetter: "bigger" | "smaller";
   units: string;
+  /**
+   * Relative importance in cross-bench aggregations (e.g. the "times
+   * best" total's weighted geometric mean). Defaults to 1.
+   */
+  weight?: number;
 }
 
 export interface ResultSet {

--- a/results/app/types.ts
+++ b/results/app/types.ts
@@ -32,11 +32,6 @@ export interface BenchmarkInfo {
   measure?: string;
   whatsBetter: "bigger" | "smaller";
   units: string;
-  /**
-   * Relative importance in cross-bench aggregations (e.g. the "times
-   * best" total's weighted geometric mean). Defaults to 1.
-   */
-  weight?: number;
 }
 
 export interface ResultSet {


### PR DESCRIPTION
Adds a `raw` / `score` / `times best` toggle to the Table view:

- **raw** (default): the values exactly as shown today
- **score**: the same `(value - min) / (max - min)` normalization the cell colors already use, shown as a 0-1 value with two decimals (ties render as `1.00`/`0.00`)
- **times best**: per row, how many times worse than the row's best each framework is — `1x` for the best, `1.1x` for 10% worse, etc. Direction-aware (`best/value` when bigger is better, `value/best` otherwise), so it's always >= 1. Rounded to two decimals with trailing zeros trimmed (`2x`, not `2.00x`). **Totals** apply the same times-best to the raw summed totals, so the best column reads `1x` there too.

(Log-score and ranking modes existed in earlier iterations of this branch and were removed by request.)

Modes are per-row and direction-agnostic like the colors, so score, times, and cell color always tell the same story: within a "higher is better" table 1.00/1x marks the best framework, and in a "lower is better" table 0.00/1x does.

**The mode is a `?mode=` query param** (route-level `queryParams` + `RouterService`, same pattern as `q`/`error` — no controllers): read from `router.currentRoute.queryParams` (tracked), set via `router.transitionTo({ queryParams: { mode } })`. `q` stays sticky, deep links render correctly, unknown modes fall back to raw, and `mode` has no `refreshModel` so toggling never refetches.

Verified in-browser against the 8x-slowdown result set: e.g. lower-table first row `2.18x / 8.61x / 1x / 1.75x / 1.1x`, totals `1x / 1.61x / 1.02x / 1.1x / 1.13x`. results lint (eslint, prettier, ember-tsc) and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)