### PR TITLE
Give prepare()'s requestIdleCallback a timeout so benches can't hollow-boot

### DIFF
--- a/common/src/tests/base-test.js
+++ b/common/src/tests/base-test.js
@@ -42,9 +42,14 @@ export class BaseTest {
 
     this.#isPreparing = true;
     requestAnimationFrame(() => {
-      requestIdleCallback(() => {
-        callback();
-      });
+      // timeout required: a bare requestIdleCallback may never fire in
+      // an idle headless page, hollow-booting the bench
+      requestIdleCallback(
+        () => {
+          callback();
+        },
+        { timeout: 500 },
+      );
     });
   }
 


### PR DESCRIPTION
Root-causes the long-standing headless flake (fan-out stuck at `[0]`, dbmon runs ending in "No marks recorded"): `prepare()`'s bare `requestIdleCallback` is allowed to defer forever in an idle headless page, so the bench sometimes never starts at all — initial shell renders, workers never boot, zero marks.

Proof: instrumenting rAF/rIC arm/fire counts, hollow boots show `{rafArm: 1, rafFire: 1, ricArm: 1, ricFire: 0}` after 8 seconds. Roughly 1 in 4 fresh-browser boots hollow-booted during ember-perf testing today; with `{ timeout: 500 }` it's 8/8 clean.

Two side notes from the same investigation, for future hardening:
- the runner records **no** marks unless `:done` appears — a hollow page produces a "successful" run with empty times; a `rows > 0` DOM sanity check in the runner (or bench `verify()`) would catch this class loudly
- a hollow page idles at the rAF cap, so an fps number can look *excellent* while measuring nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)