### PR TITLE
Fix inconsistent widths of boxplot charts

### DIFF
--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -192,6 +192,13 @@ export default class Boxplat extends Component<{
     {{/each}}
 
     <style scoped>
+      section {
+        /* the .all-results grid centers items at their content width,
+           so without a definite width each chart shrink-wraps to its
+           heading text and every chart ends up a different width */
+        width: min(90vw, 60rem);
+      }
+
       .boxplot-header {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Problem

On the boxplot results page, every chart rendered at a different width — anywhere from 300px to ~620px on the same page. The width of each chart was determined by the length of its benchmark's heading text.

Cause: `body` / `.all-results` are grids that center items at their content width, so each `<section>` shrink-wraps to its widest content — the heading (or chart.js's 300px default canvas when the heading is shorter than that). Chart.js's responsive sizing then adopts that accidental width for the canvas.

| before | after |
| --- | --- |
| canvas widths 300–618px, one per heading length | all canvases identical (`min(90vw, 60rem)`) |

## Fix

Give the boxplot sections a definite, uniform width in the component's scoped style: `width: min(90vw, 60rem)`. Verified headlessly at 1280px (all 15 canvases exactly 960px) and 480px viewports (all 432px, no horizontal scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)