### PR TITLE
Make the results site usable on mobile

### DIFF
--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -4,6 +4,9 @@
 
   --dark-bg: #151515;
   --dark-fg: #efefef;
+
+  /* whichever of the two is active, for elements that must be opaque */
+  --page-bg: var(--light-bg);
 }
 
 body {
@@ -18,6 +21,10 @@ header {
 }
 
 @media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: var(--dark-bg);
+  }
+
   body {
     background: var(--dark-bg);
     color: var(--dark-fg);
@@ -132,6 +139,17 @@ main.error-page {
   }
 }
 
+/*
+ * The page centers content at its natural width, so a wide table would
+ * otherwise expand the layout viewport on small screens and clip
+ * everything else. The vw-based cap (not a percentage) is what breaks
+ * that content-sized circularity.
+ */
+.table-scroll {
+  max-width: calc(100vw - 1rem);
+  overflow-x: auto;
+}
+
 table {
   th,
   td {
@@ -143,10 +161,20 @@ table {
     vertical-align: bottom;
   }
 
+  /* benchmark names stay readable while the value columns scroll under them */
+  .benchmark-name,
+  tfoot th {
+    position: sticky;
+    left: 0;
+    background: var(--page-bg);
+    /* cells later in the row otherwise paint over the sticky cell */
+    z-index: 1;
+  }
+
   .benchmark-name {
+    min-width: 11rem;
     text-align: right;
     display: flex;
-    position: relative;
     justify-content: end;
 
     .units {
@@ -166,7 +194,9 @@ table {
 
 .value-mode {
   display: inline-flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  max-width: calc(100vw - 1rem);
   border: 1px solid lightgray;
   padding: 0.25rem 0.75rem;
 

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -279,47 +279,55 @@ class Table extends Component<{
   };
 
   <template>
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          {{#each this.frameworkNames as |framework|}}
-            <th class="fw-header">
-              <FrameworkInfo @name={{framework}} />
-              <span class="small">
-                <Version
-                  @version={{this.versionFor framework}}
-                  @override={{this.overrideFor framework}}
-                />
-              </span>
-            </th>
-          {{/each}}
-        </tr>
-      </thead>
-      <tbody>
-        {{#each @benches as |bench|}}
-          <TableRow @file={{@file}} @benchInfo={{bench}} @frameworkNames={{this.frameworkNames}} />
-        {{/each}}
-      </tbody>
-
-      {{#if this.shouldShowTotals}}
-        <tfoot>
-          <tr><th style="text-align: right">Total</th>
+    {{! wide tables scroll in their own container instead of expanding
+        the page's layout viewport on small screens }}
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
             {{#each this.frameworkNames as |framework|}}
-              <td
-                style="background: {{colorFor
-                  (get this.totals framework)
-                  this.totals.min
-                  this.totals.max
-                }}"
-              >
-                <span class="value">{{this.totalValue framework}}</span>
-              </td>
+              <th class="fw-header">
+                <FrameworkInfo @name={{framework}} />
+                <span class="small">
+                  <Version
+                    @version={{this.versionFor framework}}
+                    @override={{this.overrideFor framework}}
+                  />
+                </span>
+              </th>
             {{/each}}
           </tr>
-        </tfoot>
-      {{/if}}
-    </table>
+        </thead>
+        <tbody>
+          {{#each @benches as |bench|}}
+            <TableRow
+              @file={{@file}}
+              @benchInfo={{bench}}
+              @frameworkNames={{this.frameworkNames}}
+            />
+          {{/each}}
+        </tbody>
+
+        {{#if this.shouldShowTotals}}
+          <tfoot>
+            <tr><th style="text-align: right">Total</th>
+              {{#each this.frameworkNames as |framework|}}
+                <td
+                  style="background: {{colorFor
+                    (get this.totals framework)
+                    this.totals.min
+                    this.totals.max
+                  }}"
+                >
+                  <span class="value">{{this.totalValue framework}}</span>
+                </td>
+              {{/each}}
+            </tr>
+          </tfoot>
+        {{/if}}
+      </table>
+    </div>
   </template>
 }
 


### PR DESCRIPTION
On a phone-sized viewport (390px), the results table's min-content width (~460px) expanded the page's layout viewport past the screen — since `body`/`.all-results` center content at its natural width, *everything* (header, env info, the benchmark-name column, the value-mode radios) got clipped and the whole page had to be panned sideways.

## Changes

- **Tables scroll in place**: each `<Table>` is wrapped in a `.table-scroll` container with `overflow-x: auto`, capped at `calc(100vw - 1rem)`. The vw-based cap (not a percentage) is what breaks the circularity of sitting inside content-sized centering grids — same lesson as the boxplot width fix (#35).
- **Sticky row labels**: `.benchmark-name` and the `Total` label are `position: sticky; left: 0` with an opaque background and `z-index: 1`, so you always know which bench you're looking at while the value columns scroll underneath. A new `--page-bg` custom property keeps the sticky background correct in dark mode (a direct dark-media override loses on source order).
- **Radios wrap**: the raw / score / times-best fieldset flex-wraps instead of overflowing.

Desktop is unchanged — the tables are narrower than the cap there, so the scroll container and sticky positioning are inert.

Verified with headless-Chrome screenshots at 390×844 (light + dark, scrolled and unscrolled) and 1440×900: no page-level horizontal overflow remains on home/table/boxplot/animated/history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)