### PR TITLE
Remove `globby`, use node's built-in glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "cosmiconfig": "^9.0.0",
     "eslint": "^9.39.3",
     "execa": "^9.6.1",
-    "globby": "^16.1.1",
     "killable": "^1.0.1",
     "prettier": "github:prettier/prettier",
     "puppeteer": "^24.37.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      globby:
-        specifier: ^16.1.1
-        version: 16.1.1
       killable:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1469,10 +1466,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  globby@16.1.1:
-    resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
-    engines: {node: '>=20'}
-
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
@@ -1681,10 +1674,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -2295,10 +2284,6 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
-
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -2523,10 +2508,6 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
-
-  unicorn-magic@0.4.0:
-    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
-    engines: {node: '>=20'}
 
   unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
@@ -4289,15 +4270,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globby@16.1.1:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      is-path-inside: 4.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.4.0
-
   globrex@0.1.2: {}
 
   gopd@1.2.0: {}
@@ -4480,8 +4452,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
-
-  is-path-inside@4.0.0: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -5195,8 +5165,6 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  slash@5.1.0: {}
-
   smart-buffer@4.2.0: {}
 
   smol-toml@1.3.1: {}
@@ -5451,8 +5419,6 @@ snapshots:
       regexp-util: 2.0.0
 
   unicorn-magic@0.3.0: {}
-
-  unicorn-magic@0.4.0: {}
 
   unified@9.2.2:
     dependencies:

--- a/src/runner/repo.ts
+++ b/src/runner/repo.ts
@@ -1,16 +1,19 @@
 import assert from 'node:assert';
+import fs from 'node:fs/promises';
 import path from 'node:path';
-
-import { globby } from 'globby';
 
 import { BENCH_NAME, FRAMEWORK } from './arg.ts';
 
 export async function getTests() {
-  let results = await globby('**/package.json', { gitignore: true });
+  /**
+   * Every app lives at frameworks/<framework>/<bench>,
+   * so there is nothing deeper to search (and no node_modules to skip).
+   */
+  const manifests = await Array.fromAsync(
+    fs.glob('frameworks/*/*/package.json'),
+  );
 
-  results = results
-    .filter((result) => result.startsWith('framework'))
-    .map((result) => path.dirname(result));
+  let results = manifests.map((manifest) => path.dirname(manifest)).sort();
 
   if (FRAMEWORK) {
     results = results.filter((result) => result.includes(`/${FRAMEWORK}/`));


### PR DESCRIPTION
Follow-up to #43, which introduced the first `fs.glob` usage. `src/runner/repo.ts` was the only remaining `globby` caller, so the dependency can go.

```js
// before
let results = await globby('**/package.json', { gitignore: true });

results = results
  .filter((result) => result.startsWith('framework'))
  .map((result) => path.dirname(result));

// after
const manifests = await Array.fromAsync(fs.glob('frameworks/*/*/package.json'));

let results = manifests.map((manifest) => path.dirname(manifest)).sort();
```

The old call walked the whole repo and then discarded everything outside `frameworks/`, so `gitignore: true` was really just there to keep the walk out of `node_modules`. `frameworks/*/*/package.json` never descends that far -- and it's the shape the asserts right below already assume (`const [, fw, name] = test.split('/')`).

One behavior change worth calling out: results are `.sort()`ed now. Neither globby nor `fs.glob` guarantees an order, so the framework/bench prompts could reorder between runs.

### Testing

Diffed `getTests()` output before and after: identical, all 30 app directories. `--framework=ember` returns the 5 ember apps and `--framework=ember --bench=fan-out` returns just `frameworks/ember/fan-out`, so both filters still work. `pnpm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)