### PR TITLE
Add a "Try Ember PR" workflow: benchmark an ember.js PR from a URL

### DIFF
--- a/.github/workflows/try-ember-pr.yml
+++ b/.github/workflows/try-ember-pr.yml
@@ -1,0 +1,202 @@
+name: "Try Ember PR"
+
+# Builds ember-source from a PR on emberjs/ember.js and opens a PR here with
+# that build installed in every ember app -- i.e. `pnpm use-tar-for ember <tgz>`,
+# but done for you, in CI.
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR on emberjs/ember.js: a URL (https://github.com/emberjs/ember.js/pull/21512) or just the number (21512)"
+        required: true
+        type: string
+      commit:
+        description: "Which commit to build: the PR merged into its base branch, or the PR's own head"
+        required: false
+        type: choice
+        options:
+          - merge
+          - head
+        default: merge
+
+concurrency:
+  group: try-ember-pr-${{ inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  try-ember-pr:
+    name: "Build the PR, install it, open a PR"
+    runs-on: ubuntu-latest
+    # installing 5 ember apps from scratch is the slow part
+    timeout-minutes: 60
+
+    steps:
+      - name: Resolve the ember PR
+        id: pr
+        env:
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+        run: |
+          node --input-type=module <<'RESOLVE'
+          import { execFileSync } from 'node:child_process';
+          import { appendFileSync } from 'node:fs';
+
+          const input = (process.env.INPUT_PR ?? '').trim();
+          /**
+           * Accepts a full URL, `owner/repo#123`, or a bare number.
+           * A bare number means emberjs/ember.js -- that's the whole point of this workflow.
+           */
+          const parsed = input
+            .replace(/^(https?:\/\/)?(www\.)?github\.com\//, '')
+            .replace(/^#/, '')
+            .match(/^(?:(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)(?:\/pull\/|#))?(?<number>\d+)/);
+
+          if (!parsed) {
+            console.error(`Could not find a PR number in "${input}"`);
+            process.exit(1);
+          }
+
+          const { owner = 'emberjs', repo = 'ember.js', number } = parsed.groups;
+          const remote = `https://github.com/${owner}/${repo}.git`;
+
+          let ref = `refs/pull/${number}/merge`;
+
+          if (process.env.INPUT_COMMIT === 'head') {
+            ref = `refs/pull/${number}/head`;
+          } else if (!execFileSync('git', ['ls-remote', remote, ref], { encoding: 'utf8' }).trim()) {
+            /**
+             * GitHub only publishes the merge ref while the PR merges cleanly,
+             * so a conflicted (or closed) PR still has a head to benchmark.
+             */
+            console.log(`No ${ref} (the PR does not merge cleanly?) -- using the PR's head instead`);
+            ref = `refs/pull/${number}/head`;
+          }
+
+          console.log(`Building ${owner}/${repo}#${number} at ${ref}`);
+
+          appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            [`repo=${owner}/${repo}`, `number=${number}`, `ref=${ref}`, ''].join('\n'),
+          );
+          RESOLVE
+
+      - name: Checkout the benchmark
+        uses: actions/checkout@v6
+        with:
+          # PRs opened (and branches pushed) with the default GITHUB_TOKEN do not
+          # trigger CI on themselves. Add a TRY_EMBER_PR_TOKEN secret (a PAT with
+          # `repo` scope) to have the benchmark workflows run on the PRs this opens.
+          token: ${{ secrets.TRY_EMBER_PR_TOKEN || github.token }}
+
+      - name: Checkout ember-source
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.pr.outputs.repo }}
+          ref: ${{ steps.pr.outputs.ref }}
+          # never committed -- only the tarball built from it is
+          path: ember-source-pr
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Build a tarball from the PR
+        working-directory: ember-source-pr
+        env:
+          NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse --short HEAD)
+          tarball="ember-source-pr-${NUMBER}-${sha}.tgz"
+
+          # ember-source pins its own pnpm via `packageManager`, which pnpm honors
+          pnpm install --frozen-lockfile
+          pnpm build
+          pnpm pack --out "${GITHUB_WORKSPACE}/${tarball}"
+
+          {
+            echo "TARBALL=${tarball}"
+            echo "EMBER_SHA=${sha}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install it in every ember app
+        run: |
+          set -euo pipefail
+          pnpm install
+          pnpm use-tar-for ember "${GITHUB_WORKSPACE}/${TARBALL}"
+
+      - name: Open the PR
+        id: open
+        env:
+          GH_TOKEN: ${{ secrets.TRY_EMBER_PR_TOKEN || github.token }}
+          EMBER_REPO: ${{ steps.pr.outputs.repo }}
+          NUMBER: ${{ steps.pr.outputs.number }}
+          REF: ${{ steps.pr.outputs.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          branch="try-ember-pr/${NUMBER}"
+          # quoted, never interpolated: the ember PR title is somebody else's input
+          ember_title=$(gh pr view "$NUMBER" --repo "$EMBER_REPO" --json title --jq .title)
+          ember_url="${GITHUB_SERVER_URL}/${EMBER_REPO}/pull/${NUMBER}"
+
+          printf '%s\n' \
+            "Benchmarking [${EMBER_REPO}#${NUMBER}](${ember_url}) -- ${ember_title}" \
+            "" \
+            "Every app in \`frameworks/ember/\` now resolves \`ember-source\` from a tarball built" \
+            "from that PR (\`${REF}\`, commit \`${EMBER_SHA}\`) instead of from npm." \
+            "" \
+            "\`\`\`bash" \
+            "gh pr checkout ${branch}" \
+            "pnpm install" \
+            "pnpm bench" \
+            "\`\`\`" \
+            "" \
+            "Then compare against a run of \`main\` in the results app." \
+            "" \
+            "The \`.tgz\` is committed past \`.gitignore\` so that a checkout of this branch" \
+            "installs the same ember every time. **Do not merge this** -- re-run" \
+            "[Try Ember PR](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/try-ember-pr.yml)" \
+            "to rebuild the branch after the ember PR changes." \
+            "" \
+            "Built by [this run](${RUN_URL})." \
+            > /tmp/try-ember-pr-body.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          # the tarball is gitignored, on purpose, for local use of use-tar-for
+          git add -f "$TARBALL"
+          git add frameworks/ember
+
+          if git diff --cached --quiet; then
+            echo "::error::Nothing to commit -- did use-tar-for change anything?"
+            exit 1
+          fi
+
+          git commit -m "Try ${EMBER_REPO}#${NUMBER} (${EMBER_SHA})"
+          git push --force origin "HEAD:refs/heads/${branch}"
+
+          title="Try ${EMBER_REPO}#${NUMBER}: ${ember_title}"
+          existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "$title" --body-file /tmp/try-ember-pr-body.md
+            url=$(gh pr view "$existing" --json url --jq .url)
+          else
+            url=$(gh pr create \
+              --base "${GITHUB_REF_NAME}" \
+              --head "$branch" \
+              --title "$title" \
+              --body-file /tmp/try-ember-pr-body.md \
+              --draft)
+          fi
+
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "[${title}](${url})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/try-ember-pr.yml
+++ b/.github/workflows/try-ember-pr.yml
@@ -86,11 +86,6 @@ jobs:
 
       - name: Checkout the benchmark
         uses: actions/checkout@v6
-        with:
-          # PRs opened (and branches pushed) with the default GITHUB_TOKEN do not
-          # trigger CI on themselves. Add a TRY_EMBER_PR_TOKEN secret (a PAT with
-          # `repo` scope) to have the benchmark workflows run on the PRs this opens.
-          token: ${{ secrets.TRY_EMBER_PR_TOKEN || github.token }}
 
       - name: Checkout ember-source
         uses: actions/checkout@v6
@@ -133,7 +128,7 @@ jobs:
       - name: Open the PR
         id: open
         env:
-          GH_TOKEN: ${{ secrets.TRY_EMBER_PR_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           EMBER_REPO: ${{ steps.pr.outputs.repo }}
           NUMBER: ${{ steps.pr.outputs.number }}
           REF: ${{ steps.pr.outputs.ref }}

--- a/README.md
+++ b/README.md
@@ -159,3 +159,21 @@ TODO: Write this
     2. `pnpm install`
     3. `pnpm start`
 
+## Benchmarking an unreleased version of a framework
+
+A PR, a nightly, a local build -- anything you can `npm pack` into a tarball:
+
+```bash
+pnpm use-tar-for ember ./path-to/ember-source.tgz
+```
+
+The tarball is copied to the root of the repo, and every app in `frameworks/ember/`
+is pointed at it. Then run the benchmark as usual, and compare the run against a
+run of `main` in the results app.
+
+For ember specifically, CI can do all of that for you: run the
+[**Try Ember PR**](../../actions/workflows/try-ember-pr.yml) workflow with a link to a
+PR on `emberjs/ember.js` (or just its number). It builds that PR, installs the build
+in every ember app, and opens a draft PR here with the result -- check it out, and
+`pnpm bench`.
+


### PR DESCRIPTION
Dispatch **Try Ember PR** with a link to a PR on `emberjs/ember.js` (or just its number) and it opens a draft PR here with every app in `frameworks/ember/` resolving `ember-source` from a build of that PR. Trying a PR becomes `gh pr checkout` + `pnpm bench`.

It is `pnpm use-tar-for ember <tgz>` (#43), with the tarball-building part done for you:

1. resolve the input -- a URL, `emberjs/ember.js#123`, or a bare number
2. check out `refs/pull/<n>/merge` (falls back to `/head` when the PR doesn't merge cleanly; there's a `commit` input to ask for `head` outright)
3. `pnpm install --frozen-lockfile && pnpm build && pnpm pack`
4. `pnpm use-tar-for ember <tgz>`
5. commit to `try-ember-pr/<n>` and open (or update) a draft PR

Re-dispatching the same PR number rebuilds that branch in place rather than opening a second PR.

### Notes

- **The `.tgz` is committed with `git add -f`**, past the `*.tgz` ignore rule -- the `file:` deps have to resolve for anyone who checks the branch out. ~2-3MB per branch, and the PR body says not to merge it.
- **`pnpm build`, not `bin/build-for-publishing.cjs`.** Ember's own bench tooling uses the latter, but it also runs yuidoc and `auto-dist-tag`, neither of which changes the built assets. `Ember.VERSION` isn't sha-stamped as a result; the tarball filename carries the sha instead.
- **CI won't run on the PRs this opens** -- PRs opened with the default `GITHUB_TOKEN` don't trigger workflows. That's fine: these branches exist to be checked out and benchmarked locally, so the workflow just uses `github.token`.
- `workflow_dispatch` only shows up in the Actions UI once the file is on the default branch, so this can't be test-dispatched until it merges.

The ember PR's title is only ever read into a shell variable and written with `printf` -- never interpolated into a `run:` block.

### Verified

The PR-parsing/ref-resolution step against the live repo (all input shapes, the merge→head fallback, and the bad-input exit), `bash -n` on every `run:` block, YAML parse, prettier, and that `pnpm pack --out` succeeds on `ember-source` (2MB tarball; the missing `docs/data.json` in `files` is skipped, not an error). `pnpm build` itself is what ember's `build-test` CI job runs on every PR.

README gains a "Benchmarking an unreleased version of a framework" section documenting `use-tar-for` -- which wasn't documented -- and this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

