### PR TITLE
Give tryVerify's requestIdleCallback retries a timeout

### DIFF
--- a/common/src/tests/utils.js
+++ b/common/src/tests/utils.js
@@ -30,9 +30,17 @@ export function tryVerify(label, check, attempts = 0) {
   }
 
   if (attempts < NUM_FRAMES_TO_WAIT) {
-    requestIdleCallback(() => {
-      tryVerify(label, check, attempts + 1);
-    });
+    // The timeout keeps the retry loop honest in two ways: a fully idle
+    // page can starve requestIdleCallback entirely (the arm-but-never-fire
+    // failure #34 fixed in base-test), and unbounded idle-grant latency
+    // taxes frameworks that defer rendering past the dirtying task by
+    // hundreds of ms of pure measurement noise on `:done`.
+    requestIdleCallback(
+      () => {
+        tryVerify(label, check, attempts + 1);
+      },
+      { timeout: 50 },
+    );
     return;
   }
 


### PR DESCRIPTION
`tryVerify` in `common/src/tests/utils.js` escaped #34's fix: its retry loop re-arms a **bare** `requestIdleCallback`, which has two failure modes we hit while benchmarking ember scheduler builds:

1. **Starvation hang**: a fully idle page can simply never grant an idle callback (same mechanism as #34) — we reproduced `:done` never firing within 180s, on *stock* framework builds too.
2. **Measurement noise on deferred renderers**: any framework that defers rendering past the dirtying task (Angular zoneless, the ember scheduler PRs) fails the first `check()`, and the retry then waits on the browser's idle discretion — we measured hundreds of ms of `:done` inflation vs the actual last DOM mutation.

A `{ timeout: 50 }` bounds each retry's latency without changing the idle-friendly fast path. With ~960 retry attempts allowed, worst-case wall time stays generous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)