### PR TITLE
Add `--framework/--bench=all` and `--<framework>=<pr>` to the runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ TODO: Write this
 
     There are interactive prompts to choose which frameworks / benchmarks to run.
 
+    To skip the picking, `pnpm bench --framework=all --bench=all` runs everything.
+    (Every flag is listed in the table the runner prints on start up.)
+
 4. Wait for it to finish    
 5. View results:
     1. `cd results`
@@ -170,6 +173,17 @@ pnpm use-tar-for ember ./path-to/ember-source.tgz
 The tarball is copied to the root of the repo, and every app in `frameworks/ember/`
 is pointed at it. Then run the benchmark as usual, and compare the run against a
 run of `main` in the results app.
+
+The version number that gets recorded for such a run is whatever the branch happened
+to be cut from, which says nothing about what was measured -- so tell the runner where
+the build came from, and the results app links to the PR instead:
+
+```bash
+pnpm bench --framework=all --bench=all --ember=https://github.com/emberjs/ember.js/pull/21514
+```
+
+`--<framework>=<pr>` works for every framework in `results/app/frameworks.ts`
+(`--vue=`, `--svelte=`, ...), and takes a link or `owner/repo#number`.
 
 For ember specifically, CI can do all of that for you: run the
 [**Try Ember PR**](../../actions/workflows/try-ember-pr.yml) workflow with a link to a

--- a/src/runner/arg.ts
+++ b/src/runner/arg.ts
@@ -1,6 +1,16 @@
 import { styleText } from 'node:util';
 
+import { frameworks } from '../../results/app/frameworks.ts';
+
+import type { VersionOverride } from '../../results/app/types.ts';
+
 const [, , ...args] = process.argv;
+
+/**
+ * `--framework=all` / `--bench=all` selects everything,
+ * instead of asking.
+ */
+export const ALL = 'all';
 
 export const HEADLESS = bool('--headless');
 export const COUNT = int('--count', 10);
@@ -8,6 +18,7 @@ export const CPU_THROTTLE = int('--cpu-throttle', 1);
 export const FRAMEWORK = str('--framework');
 export const BENCH_NAME = str('--bench');
 export const SKIP_BUILD = bool('--skip-build');
+export const VERSION_OVERRIDES = versionOverrides();
 
 function col1(name: string) {
   return styleText('yellow', name.padEnd(16));
@@ -41,8 +52,15 @@ console.log(
     ),
     row(col1('--headless'), col2(HEADLESS), col3('limited to 60 fps')),
     row(col1('--count'), col2(COUNT), col3('sample count')),
-    row(col1('--framework'), col2(FRAMEWORK), ''),
-    row(col1('--bench'), col2(BENCH_NAME), ''),
+    row(col1('--framework'), col2(FRAMEWORK), col3(`or '${ALL}'`)),
+    row(col1('--bench'), col2(BENCH_NAME), col3(`or '${ALL}'`)),
+    ...Object.entries(VERSION_OVERRIDES).map(([framework, override]) =>
+      row(
+        col1(`--${framework}`),
+        col2(`#${override.number}`),
+        col3(override.url),
+      ),
+    ),
   ]
     .map((line) => '\t' + line)
     .join('\n'),
@@ -56,6 +74,66 @@ function str(name: string) {
   const arg = args.find((a) => a.startsWith(name));
 
   return arg?.split('=')[1];
+}
+
+/**
+ * Unlike {@link str}, `--ember` must not answer for `--ember-canary`.
+ */
+function exact(name: string) {
+  const arg = args.find((a) => a.split('=')[0] === name);
+
+  return arg?.split('=').slice(1).join('=');
+}
+
+/**
+ * `--ember=<link to a PR>` (and the same for every other framework) records
+ * which PR a framework's build came from -- as `pnpm use-tar-for` installs a
+ * tarball, the installed version number is whatever the PR happened to be
+ * branched from, and says nothing about what was measured.
+ *
+ * The results app links to the PR in place of that version.
+ */
+function versionOverrides() {
+  const overrides: Record<string, VersionOverride> = {};
+
+  for (const framework of Object.keys(frameworks)) {
+    const value = exact(`--${framework}`);
+
+    if (!value) continue;
+
+    const override = toPullRequest(value);
+
+    if (!override) {
+      console.error(
+        `--${framework}=${value} is not a pull request. ` +
+          `Expected a link (https://github.com/emberjs/ember.js/pull/21514) ` +
+          `or emberjs/ember.js#21514`,
+      );
+      process.exit(1);
+    }
+
+    overrides[framework] = override;
+  }
+
+  return overrides;
+}
+
+function toPullRequest(value: string): VersionOverride | undefined {
+  const parsed = value
+    .trim()
+    .replace(/^(https?:\/\/)?(www\.)?github\.com\//, '')
+    .match(/^(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)(?:\/pull\/|#)(?<number>\d+)/);
+
+  if (!parsed?.groups) return;
+
+  const { owner, repo, number } = parsed.groups;
+
+  return {
+    number: Number(number),
+    // rebuilt, so that a link copied from a /files or #discussion view still
+    // points at the PR itself
+    url: `https://github.com/${owner}/${repo}/pull/${number}`,
+  };
 }
 
 function int(name: string, defaultValue: number) {

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -7,7 +7,7 @@ import * as clack from '@clack/prompts';
 import * as args from './arg.ts';
 import { yyyymmdd } from './environment.ts';
 import { frameworks } from './repo.ts';
-import { info, saveBenchmarkInfo } from './results.ts';
+import { info, saveBenchmarkInfo, saveVersionOverrides } from './results.ts';
 
 export interface BenchmarkInfo {
   /**
@@ -191,6 +191,10 @@ const benchmarks: BenchmarkInfo[] = [
 ];
 
 async function getFrameworks() {
+  if (args.FRAMEWORK === args.ALL) {
+    return [...frameworks.values()];
+  }
+
   let selectedFrameworks: string[] | undefined = args.FRAMEWORK
     ? [args.FRAMEWORK]
     : undefined;
@@ -215,6 +219,10 @@ async function getFrameworks() {
 }
 
 async function getBenches() {
+  if (args.BENCH_NAME === args.ALL) {
+    return benchmarks;
+  }
+
   let preselected: BenchmarkInfo | undefined;
 
   if (args.BENCH_NAME) {
@@ -274,6 +282,15 @@ async function getFilePath() {
 
 export async function getBenchInfo() {
   const selectedFrameworks = await getFrameworks();
+
+  for (const framework of Object.keys(args.VERSION_OVERRIDES)) {
+    if (selectedFrameworks.includes(framework)) continue;
+
+    clack.log.warn(
+      `--${framework} was given a PR, but ${framework} is not being benchmarked`,
+    );
+  }
+
   const selectedBenches = await getBenches();
   const filePath = await getFilePath();
 
@@ -303,6 +320,8 @@ export async function getBenchInfo() {
     },
     filePath,
   );
+
+  await saveVersionOverrides(args.VERSION_OVERRIDES, filePath);
 
   return {
     apps,

--- a/src/runner/repo.ts
+++ b/src/runner/repo.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { BENCH_NAME, FRAMEWORK } from './arg.ts';
+import { ALL, BENCH_NAME, FRAMEWORK } from './arg.ts';
 
 export async function getTests() {
   /**
@@ -15,11 +15,11 @@ export async function getTests() {
 
   let results = manifests.map((manifest) => path.dirname(manifest)).sort();
 
-  if (FRAMEWORK) {
+  if (FRAMEWORK && FRAMEWORK !== ALL) {
     results = results.filter((result) => result.includes(`/${FRAMEWORK}/`));
   }
 
-  if (BENCH_NAME) {
+  if (BENCH_NAME && BENCH_NAME !== ALL) {
     results = results.filter((result) => result.includes(`${BENCH_NAME}`));
   }
 

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -12,6 +12,7 @@ import {
 } from '../../results/app/frameworks.ts';
 import { getInfo } from './environment.ts';
 
+import type { VersionOverride } from '../../results/app/types.ts';
 import type { BenchmarkInfo } from './bench-info.ts';
 
 const require = createRequire(import.meta.url);
@@ -95,6 +96,23 @@ export async function saveBenchmarkInfo(
 
     return rest;
   });
+
+  await write(file, filePath);
+}
+
+/**
+ * Which PR each framework's build came from, when it came from one.
+ * Merged in, so appending to an existing file keeps the runs already in it.
+ */
+export async function saveVersionOverrides(
+  overrides: Record<string, VersionOverride>,
+  filePath: string,
+) {
+  if (Object.keys(overrides).length === 0) return;
+
+  const file = await read(filePath);
+
+  file.versionOverrides = { ...file.versionOverrides, ...overrides };
 
   await write(file, filePath);
 }


### PR DESCRIPTION
Two things that were annoying about running the benchmark locally.

### `--framework=all` / `--bench=all`

```bash
pnpm bench --framework=all --bench=all
```

Selects everything instead of asking, so a full run doesn't start with two multiselects. The "Where to save?" and "does this look correct?" prompts still run -- this pre-selects, it doesn't go non-interactive.

### `--<framework>=<pr>`

```bash
pnpm bench --framework=all --bench=all --ember=https://github.com/emberjs/ember.js/pull/21514
```

writes what #37 wrote by hand:

```json
"versionOverrides": {
  "ember": { "number": 21514, "url": "https://github.com/emberjs/ember.js/pull/21514" }
}
```

When a framework is installed from a tarball (`pnpm use-tar-for`, or a branch from the Try Ember PR workflow), the recorded version is whatever the branch was cut from and says nothing about what was measured. The results app already links to the PR instead when the result set has a `versionOverride` -- now the runner can fill it in.

Works for every framework in `results/app/frameworks.ts` (`--vue=`, `--svelte=`, `--ember-canary=`, ...), and takes either a link or `owner/repo#number`. A `/files` or `#issuecomment` link is normalized back to the PR URL. A value that isn't a PR exits at parse time listing the accepted forms rather than writing junk into the result set. The runner warns before the confirm prompt if you pass a PR for a framework you aren't benchmarking.

The flags show up in the table the runner prints at start up:

```
	--framework     all       or 'all'
	--bench         all       or 'all'
	--ember         #21514    https://github.com/emberjs/ember.js/pull/21514
```

### Notes

- `--ember` deliberately does not answer for `--ember-canary` -- the existing `str()` helper matches by prefix, so these parse the flag name exactly.
- Writes are merged, so pointing a run at an existing result set keeps the overrides, results, and timing already in it.

### Verified

`all` yields all 6 frameworks x 5 apps, and `--framework=ember` / `--bench=fan-out` / no-flags are unchanged. Override writing was exercised against both a fresh path and a copy of `2026-07-23T03:43:33.440Z.json` (results and timing intact, override added), plus the no-overrides case (no file written) and the invalid-value case (exit 1). Lint and prettier pass; `tsc --noEmit` reports the same three errors as `main` and no new ones.

### Unrelated, noticed while in here

`--bench=<value>` is inconsistent for non-`all` values: `repo.ts` filters app directory names (`fan-out`) while `bench-info.ts` matches the full display name (`1 value, 1k consumers, ...`), so `--bench=fan-out` narrows the build list but still drops you into the multiselect. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
