### PR TITLE
Nest the ember dbmon popover inside its <td>, like every other framework

### DIFF
--- a/frameworks/ember/dbmon-with-chat/app/templates/application.gts
+++ b/frameworks/ember/dbmon-with-chat/app/templates/application.gts
@@ -56,11 +56,13 @@ export default class Test extends Component {
                 </span>
               </td>
               {{#each row.lastSample.topFiveQueries key="@index" as |query|}}
-                <td>{{query.elapsed}}</td>
-                <div class="popover bottom">
-                  <div class="popover-content">{{query.query}}</div>
-                  <div class="arrow"></div>
-                </div>
+                <td>
+                  {{query.elapsed}}
+                  <div class="popover bottom">
+                    <div class="popover-content">{{query.query}}</div>
+                    <div class="arrow"></div>
+                  </div>
+                </td>
               {{/each}}
             </tr>
           {{/each}}


### PR DESCRIPTION
The popover div in the ember dbmon app is a **sibling** of the `<td>` — a `<div>` parented directly to a `<tr>`. All five other frameworks nest it inside the cell.

Built each app and inspected the live DOM. Before:

```
tr children:     td,td,td,div,td,div,td,div,td,div,td,div
.popover parent: tr
```

After — byte-identical shape to the react and vue builds:

```
tr children:     td,td,td,td,td,td,td
.popover parent: td
```

A `<div>` parented to a `<tr>` is not a table cell, so the browser wraps each one in an anonymous table cell. That is 200 extra boxes per render, a different box tree, and different layout work — on the one bench that measures frame rate.

Ember scores 67–76 FPS on this bench where angular/react/svelte sit pinned at the 119Hz refresh ceiling. That gap may well be real, but it can't be read until every framework is laying out the same DOM.

Found while auditing benchmark measurement methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)