### PR TITLE
Show a percentile of each run's samples, not the mean, and let you pick it

### DIFF
--- a/results/app/routes/compare.ts
+++ b/results/app/routes/compare.ts
@@ -32,6 +32,8 @@ export default class Compare extends Route<Model> {
     b: { refreshModel: true },
     // which framework to compare; both runs are already loaded, so no model impact
     framework: {},
+    // which percentile of each run's samples to show (50 | 75 | 90)
+    p: {},
   };
 
   beforeModel(transition: Transition) {

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -22,6 +22,9 @@ export default class Results extends Route<Model> {
     q: { refreshModel: true },
     // display mode for the tables page (raw | linear | log); no model impact
     mode: {},
+    // which percentile of each run's samples to show (50 | 75 | 90);
+    // every sample is already loaded, so no model impact
+    p: {},
   };
 
   beforeModel(transition: Transition) {

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -201,6 +201,16 @@ table {
     z-index: 3;
   }
 
+  /* names the statistic every cell in the table is, over the column of
+     benchmark names it labels */
+  .stat-label {
+    text-align: right;
+    font-weight: normal;
+    font-size: 0.8rem;
+    opacity: 0.6;
+    white-space: nowrap;
+  }
+
   .fw-header {
     text-align: center;
     vertical-align: bottom;

--- a/results/app/templates/compare.gts
+++ b/results/app/templates/compare.gts
@@ -13,8 +13,11 @@ import { nameOf } from "#frameworks";
 import {
   getFrameworks,
   higherIsBetterBenches,
+  labelFor,
   lowerIsBetterBenches,
   overrideOf,
+  percentileFrom,
+  PERCENTILES,
   round,
   throttleLabel,
   timeFor,
@@ -24,6 +27,7 @@ import {
 import type RouterService from "@ember/routing/router-service";
 import type { Model, NamedRun } from "#routes/compare.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
+import type { Percentile } from "#utils";
 
 /**
  * Below this |% change|, runs are considered equivalent -- individual
@@ -89,11 +93,15 @@ class CompareTable extends Component<{
   b: NamedRun;
   framework: string;
 }> {
+  @service declare router: RouterService;
+
   @cached
   get rows() {
+    const percentile = percentileFrom(this.router);
+
     return this.args.benches.map((bench) => {
-      const a = timeFor(this.args.a.data, this.args.framework, bench);
-      const b = timeFor(this.args.b.data, this.args.framework, bench);
+      const a = timeFor(this.args.a.data, this.args.framework, bench, percentile);
+      const b = timeFor(this.args.b.data, this.args.framework, bench, percentile);
 
       return {
         bench,
@@ -299,6 +307,18 @@ export default class Compare extends Component<{ model: Model }> {
 
   isRun = (which: "a" | "b", name: string) => this[which].name === name;
 
+  percentiles = PERCENTILES;
+
+  labelFor = labelFor;
+
+  isPercentile = (percentile: Percentile) => percentileFrom(this.router) === percentile;
+
+  setPercentile = (event: Event) => {
+    const { value } = event.target as HTMLSelectElement;
+
+    this.router.transitionTo({ queryParams: { p: value } });
+  };
+
   <template>
     {{pageTitle "Compare"}}
 
@@ -327,6 +347,16 @@ export default class Compare extends Component<{ model: Model }> {
         <select name="run-b" {{on "change" (fn this.setRun "b")}}>
           {{#each results as |name|}}
             <option value={{name}} selected={{this.isRun "b" name}}>{{shortName name}}</option>
+          {{/each}}
+        </select>
+      </label>
+      <label>
+        statistic
+        <select name="percentile" {{on "change" this.setPercentile}}>
+          {{#each this.percentiles as |percentile|}}
+            <option value={{percentile}} selected={{this.isPercentile percentile}}>{{this.labelFor
+                percentile
+              }}</option>
           {{/each}}
         </select>
       </label>

--- a/results/app/templates/results/animated.gts
+++ b/results/app/templates/results/animated.gts
@@ -1,17 +1,25 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
+import { service } from "@ember/service";
 
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { Version } from "#components/version.gts";
-import { dataOf, round } from "#utils";
+import { dataOf, percentileFrom, round } from "#utils";
 
+import type RouterService from "@ember/routing/router-service";
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, Results, ResultSet } from "#types";
 
 export default class Animated extends Component<{
   model: Model;
 }> {
+  @service declare router: RouterService;
+
+  get percentile() {
+    return percentileFrom(this.router);
+  }
+
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo
       .toSorted()
@@ -23,7 +31,7 @@ export default class Animated extends Component<{
       <Visualize
         @benchInfo={{benchInfo}}
         @file={{@model.data}}
-        @results={{dataOf @model.data.results benchInfo.name}}
+        @results={{dataOf @model.data.results benchInfo.name this.percentile}}
       />
     {{/each}}
   </template>

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -6,6 +6,7 @@ import { converter, filterBrightness, formatCss } from "culori";
 import { modifier } from "ember-modifier";
 
 import { frameworks } from "#frameworks";
+import { samplesOf } from "#utils";
 
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
@@ -29,22 +30,8 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo) {
     labels.push(framework);
 
     const marks = file.results[framework]?.[benchInfo.name]?.times;
-    let frameworkData: number[] = [];
 
-    if (marks) {
-      if (benchInfo.whatsBetter === "bigger") {
-        frameworkData = marks
-          .flat()
-          .filter((mark) => mark.name === benchInfo.measure)
-          .map((mark) => mark.detail);
-      } else {
-        frameworkData = marks
-          .map(([start, end]) => (start && end ? end.at - start.at : undefined))
-          .filter((duration) => duration !== undefined);
-      }
-    }
-
-    data.push(frameworkData);
+    data.push(marks ? samplesOf(marks, benchInfo.measure) : []);
 
     const baseColor = frameworks[framework]?.color ?? "#888";
     const hsl = HSL(baseColor);

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -410,7 +410,7 @@ export default class ResultsTables extends Component<{
       {{/each}}
       {{! percentiles run toward the worse end either way, so the same
           number means the same thing on both tables }}
-      <span class="units">of each run's samples; higher p = further into the bad tail</span>
+      <span class="units">of each run's samples</span>
     </fieldset>
 
     {{#if this.higherBenches.length}}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -10,17 +10,20 @@ import { FrameworkInfo } from "#components/framework-info.gts";
 import { Version } from "#components/version.gts";
 import {
   higherIsBetterBenches,
+  labelFor,
   lowerIsBetterBenches,
   overrideOf,
+  percentileFrom,
+  PERCENTILES,
   round,
   timeFor,
   versionOf,
 } from "#utils";
 
-import type Owner from "@ember/owner";
 import type RouterService from "@ember/routing/router-service";
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
+import type { Percentile } from "#utils";
 
 const start = "#ff7777";
 const end = "#77ff77";
@@ -83,13 +86,18 @@ function formatTimes(ratio: number) {
   return `${Math.round(ratio * 100) / 100}x`;
 }
 
-function speedsFor(file: ResultSet, benchInfo: BenchmarkInfo, frameworkNames: string[]) {
+function speedsFor(
+  file: ResultSet,
+  benchInfo: BenchmarkInfo,
+  frameworkNames: string[],
+  percentile: Percentile,
+) {
   const speeds: Record<string, number | undefined> = {};
   let min = Infinity;
   let max = -Infinity;
 
   for (const framework of frameworkNames) {
-    const time = timeFor(file, framework, benchInfo);
+    const time = timeFor(file, framework, benchInfo, percentile);
 
     if (time === undefined) continue;
 
@@ -109,49 +117,47 @@ class TableRow extends Component<{
 }> {
   @service declare router: RouterService;
 
-  declare speeds: Record<string, number | undefined>;
-  declare colors: Record<string, string | undefined>;
-  max = -Infinity;
-  min = Infinity;
+  /**
+   * Derived, not constructor-assigned: the percentile is read off the URL,
+   * so every one of these has to fall out again when it changes.
+   */
+  @cached
+  get row() {
+    const { speeds, min, max } = speedsFor(
+      this.args.file,
+      this.args.benchInfo,
+      this.args.frameworkNames,
+      percentileFrom(this.router),
+    );
 
-  constructor(
-    owner: Owner,
-    args: {
-      file: ResultSet;
-      benchInfo: BenchmarkInfo;
-      frameworkNames: string[];
-    },
-  ) {
-    super(owner, args);
+    const colors: Record<string, string | undefined> = {};
 
-    const { speeds, min, max } = speedsFor(args.file, args.benchInfo, args.frameworkNames);
-
-    this.speeds = speeds;
-    this.min = min;
-    this.max = max;
-    this.colors = {};
-
-    for (const framework of args.frameworkNames) {
-      const time = this.speeds[framework];
-
-      this.colors[framework] = colorFor(
-        time,
-        this.min,
-        this.max,
-        args.benchInfo.whatsBetter === "bigger",
+    for (const framework of this.args.frameworkNames) {
+      colors[framework] = colorFor(
+        speeds[framework],
+        min,
+        max,
+        this.args.benchInfo.whatsBetter === "bigger",
       );
     }
+
+    return { speeds, min, max, colors };
+  }
+
+  get colors() {
+    return this.row.colors;
   }
 
   value = (framework: string) => {
-    const speed = this.speeds[framework];
+    const { speeds, min, max } = this.row;
+    const speed = speeds[framework];
     const bestIsMax = this.args.benchInfo.whatsBetter === "bigger";
 
     switch (modeFrom(this.router)) {
       case "linear":
-        return scoreFor(speed, this.min, this.max);
+        return scoreFor(speed, min, max);
       case "times": {
-        const ratio = timesBestFor(speed, this.min, this.max, bestIsMax);
+        const ratio = timesBestFor(speed, min, max, bestIsMax);
 
         return ratio === undefined ? undefined : formatTimes(ratio);
       }
@@ -180,46 +186,54 @@ class Table extends Component<{
 }> {
   @service declare router: RouterService;
 
-  shouldShowTotals = false;
-  totals: Record<string, number> = {};
+  get shouldShowTotals() {
+    return this.args.benches.length > 1;
+  }
 
-  constructor(
-    owner: Owner,
-    args: {
-      benches: BenchmarkInfo[];
-      file: ResultSet;
-    },
-  ) {
-    super(owner, args);
+  get percentile() {
+    return percentileFrom(this.router);
+  }
 
-    this.shouldShowTotals = this.args.benches.length > 1;
+  get statLabel() {
+    return labelFor(this.percentile);
+  }
 
-    if (this.shouldShowTotals) {
-      for (const bench of args.benches) {
-        for (const framework of args.file.selections.frameworks) {
-          this.totals[framework] ??= 0;
+  /**
+   * Derived, not constructor-assigned: the percentile is read off the URL,
+   * so the totals have to fall out again when it changes.
+   */
+  @cached
+  get totals() {
+    const totals: Record<string, number> = {};
 
-          const time = timeFor(args.file, framework, bench);
+    if (!this.shouldShowTotals) return totals;
 
-          if (time === undefined) continue;
+    for (const bench of this.args.benches) {
+      for (const framework of this.args.file.selections.frameworks) {
+        totals[framework] ??= 0;
 
-          this.totals[framework] += time;
-        }
+        const time = timeFor(this.args.file, framework, bench, this.percentile);
+
+        if (time === undefined) continue;
+
+        totals[framework] += time;
       }
-
-      let max = -Infinity;
-      let min = Infinity;
-
-      for (const [key, value] of Object.entries(this.totals)) {
-        this.totals[key] = round(value);
-
-        if (value > max) max = value;
-        if (value < min) min = value;
-      }
-
-      this.totals.max = max;
-      this.totals.min = min;
     }
+
+    let max = -Infinity;
+    let min = Infinity;
+
+    for (const [key, value] of Object.entries(totals)) {
+      totals[key] = round(value);
+
+      if (value > max) max = value;
+      if (value < min) min = value;
+    }
+
+    totals.max = max;
+    totals.min = min;
+
+    return totals;
   }
 
   get frameworkNames() {
@@ -255,7 +269,11 @@ class Table extends Component<{
     <table class="results-table">
       <thead>
         <tr>
-          <th></th>
+          {{! which number every cell below is, stated where a reader
+              looking at a cell is already looking }}
+          <th class="stat-label" title="every cell is the {{this.statLabel}} of that run's samples">
+            {{this.statLabel}}
+          </th>
           {{#each this.frameworkNames as |framework|}}
             <th class="fw-header">
               <FrameworkInfo @name={{framework}} />
@@ -311,6 +329,20 @@ export default class ResultsTables extends Component<{
 
   isMode = (mode: ValueMode) => this.mode === mode;
 
+  percentiles = PERCENTILES;
+
+  get percentile(): Percentile {
+    return percentileFrom(this.router);
+  }
+
+  setPercentile = (percentile: Percentile) => {
+    this.router.transitionTo({ queryParams: { p: percentile } });
+  };
+
+  isPercentile = (percentile: Percentile) => this.percentile === percentile;
+
+  labelFor = labelFor;
+
   get file() {
     return this.args.model.data;
   }
@@ -361,6 +393,24 @@ export default class ResultsTables extends Component<{
         times best
         <span class="units">(1x is best)</span>
       </label>
+    </fieldset>
+
+    <fieldset class="value-mode">
+      <legend>statistic</legend>
+      {{#each this.percentiles as |percentile|}}
+        <label>
+          <input
+            type="radio"
+            name="percentile"
+            checked={{this.isPercentile percentile}}
+            {{on "change" (fn this.setPercentile percentile)}}
+          />
+          {{this.labelFor percentile}}
+        </label>
+      {{/each}}
+      {{! percentiles run toward the worse end either way, so the same
+          number means the same thing on both tables }}
+      <span class="units">of each run's samples; higher p = further into the bad tail</span>
     </fieldset>
 
     {{#if this.higherBenches.length}}

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -2,6 +2,7 @@ import { assert, warn } from "@ember/debug";
 
 import { frameworks } from "./frameworks.ts";
 
+import type RouterService from "@ember/routing/router-service";
 import type { BenchmarkInfo, Mark, ResultData, ResultSet } from "#types";
 
 function versionsOf(file: ResultSet, framework: string) {
@@ -51,12 +52,17 @@ export function overrideOf(file: ResultSet, framework: string) {
  * How one framework did at one benchmark, or undefined when that run
  * doesn't have the pair.
  */
-export function timeFor(file: ResultSet, framework: string, bench: BenchmarkInfo) {
+export function timeFor(
+  file: ResultSet,
+  framework: string,
+  bench: BenchmarkInfo,
+  percentile: Percentile,
+) {
   const test = file.results[framework]?.[bench.name];
 
   if (!test) return;
 
-  return timeFromMarks(test.times, bench.measure);
+  return timeFromMarks(test.times, bench.measure, percentile, bench.whatsBetter === "bigger");
 }
 
 /**
@@ -183,18 +189,61 @@ export function samplesOf(times: Array<Mark[]>, measure: string | undefined) {
   return measure ? detailsOf(times, measure) : durationsOf(times);
 }
 
-function mean(values: number[]) {
+export const PERCENTILES = [50, 75, 90] as const;
+
+export type Percentile = (typeof PERCENTILES)[number];
+
+export const DEFAULT_PERCENTILE: Percentile = 50;
+
+/**
+ * p50 is the median.
+ *
+ * Percentiles run toward the *worse* end of the distribution whichever
+ * direction is better, so pXX always reads "XX% of samples came in at
+ * least this good": for a duration that is the slow tail, for a frame rate
+ * it is the low tail.
+ *
+ * Interpolates between order statistics (the same method as Excel's
+ * PERCENTILE.INC and numpy's default), so p50 of an even-sized sample is
+ * the midpoint of the middle two -- the median as anyone would compute it
+ * by hand.
+ */
+export function percentileOf(values: number[], percentile: Percentile, biggerIsBetter: boolean) {
   if (values.length === 0) return NaN;
 
-  let total = 0;
+  const sorted = values.toSorted((a, b) => a - b);
+  const towardWorst = biggerIsBetter ? 100 - percentile : percentile;
+  const rank = ((sorted.length - 1) * towardWorst) / 100;
+  const below = Math.floor(rank);
+  const above = Math.ceil(rank);
+  const value = sorted[below] as number;
 
-  values.forEach((value) => (total += value));
+  if (below === above) return value;
 
-  return total / values.length;
+  return value + (rank - below) * ((sorted[above] as number) - value);
 }
 
-export function timeFromMarks(times: Array<Mark[]>, measure: string | undefined) {
-  return round(mean(samplesOf(times, measure)));
+export function timeFromMarks(
+  times: Array<Mark[]>,
+  measure: string | undefined,
+  percentile: Percentile,
+  biggerIsBetter: boolean,
+) {
+  return round(percentileOf(samplesOf(times, measure), percentile, biggerIsBetter));
+}
+
+/**
+ * The `?p=` query param, wherever a component needs it.
+ * router.currentRoute is tracked, so reads stay live across transitions.
+ */
+export function percentileFrom(router: RouterService): Percentile {
+  const found = PERCENTILES.find((p) => String(p) === router.currentRoute?.queryParams["p"]);
+
+  return found ?? DEFAULT_PERCENTILE;
+}
+
+export function labelFor(percentile: Percentile) {
+  return percentile === 50 ? "p50 (median)" : `p${percentile}`;
 }
 
 export function isBiggerBetter(results: { whatsBetter: string }): boolean {
@@ -212,7 +261,7 @@ export function lowerIsBetterBenches(benchmarkInfo: BenchmarkInfo[]) {
     .toSorted((a, b) => (a.name.includes("async") ? 1 : 0) - (b.name.includes("async") ? 1 : 0));
 }
 
-export function dataOf(results: ResultData, benchName: string) {
+export function dataOf(results: ResultData, benchName: string, percentile: Percentile) {
   const list = [];
 
   for (const [framework, benches] of Object.entries(results)) {
@@ -234,7 +283,12 @@ export function dataOf(results: ResultData, benchName: string) {
       continue;
     }
 
-    const time = timeFromMarks(benchData.times, benchData.measure);
+    const time = timeFromMarks(
+      benchData.times,
+      benchData.measure,
+      percentile,
+      benchData.whatsBetter === "bigger",
+    );
 
     list.push({
       name: framework,

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -119,55 +119,82 @@ export function msOfFrameAt(hz: number) {
   return Math.round(result * 100) / 100;
 }
 
-function averageOf(arrayOfMarks: Array<Mark[]>) {
-  const durations = [];
+/**
+ * Every bench brackets its work with these two marks.
+ *
+ * Matched exactly. They used to be matched with `endsWith`, which quietly
+ * answers to any other mark a framework or a future harness change might
+ * emit -- and the first match wins, so a stray `:start`-suffixed mark
+ * silently redefines where the measurement began.
+ */
+const START = ":start";
+const DONE = ":done";
 
-  for (const pair of arrayOfMarks) {
-    const start = pair.find((x) => x.name.endsWith("start"));
-    const done = pair.find((x) => x.name.endsWith("done"));
+/**
+ * The duration of each run, from a run's marks.
+ */
+function durationsOf(runs: Array<Mark[]>) {
+  const durations: number[] = [];
 
-    if (!done || !start) {
+  for (const marks of runs) {
+    const start = marks.find((mark) => mark.name === START);
+    const done = marks.find((mark) => mark.name === DONE);
+
+    if (!start || !done) {
       console.warn(`Dataset could have missing data`);
-      console.debug(arrayOfMarks);
+      console.debug(runs);
       continue;
     }
 
-    const duration = done.at - start.at;
-
-    durations.push(duration);
+    durations.push(done.at - start.at);
   }
 
-  let total = 0;
-
-  durations.forEach((d) => (total += d));
-
-  return round(total / durations.length);
+  return durations;
 }
 
-function averageOfNamedMark(sampleBuckets: Array<Mark[]>, name: string) {
-  const fps = [];
+/**
+ * Benches that sample rather than complete (dbmon) record each sample as
+ * the detail of a named mark, and every sample counts -- one run can carry
+ * several of them.
+ */
+function detailsOf(runs: Array<Mark[]>, name: string) {
+  const details: number[] = [];
 
-  for (const list of sampleBuckets) {
-    for (const mark of list) {
+  for (const marks of runs) {
+    for (const mark of marks) {
       if (mark.name === name) {
-        fps.push(mark.detail);
+        details.push(mark.detail);
       }
     }
   }
 
+  return details;
+}
+
+/**
+ * Every measured value for one framework at one bench, in run order.
+ *
+ * The single place marks become numbers: the summary table and the
+ * boxplots used to extract them separately -- and differently, one by name
+ * and one by position -- so the same dataset could put a framework in a
+ * different place depending on which of the two you were looking at.
+ */
+export function samplesOf(times: Array<Mark[]>, measure: string | undefined) {
+  return measure ? detailsOf(times, measure) : durationsOf(times);
+}
+
+function mean(values: number[]) {
+  if (values.length === 0) return NaN;
+
   let total = 0;
 
-  fps.forEach((f) => (total += f));
+  values.forEach((value) => (total += value));
 
-  return round(total / fps.length);
+  return total / values.length;
 }
 
 export function timeFromMarks(times: Array<Mark[]>, measure: string | undefined) {
-  if (measure) {
-    return averageOfNamedMark(times, measure);
-  }
-
-  return averageOf(times);
+  return round(mean(samplesOf(times, measure)));
 }
 
 export function isBiggerBetter(results: { whatsBetter: string }): boolean {


### PR DESCRIPTION
> **Stacked on #50.** This branch contains #50's commit too (cross-repo PRs can't target a fork branch). Merge #50 first and this diff collapses to its own second commit — or review just [`9c1a5d2`](https://github.com/NullVoxPopuli/rere-benchmark/pull/51/commits).

The headline number in the tables was the arithmetic mean of all 10 samples. Samples here aren't normally distributed around a true value — a GC pause, an OS hiccup, or a missed idle-callback slot adds a one-sided lump, and the mean carries all of it.

Across the 2026-07-23 run, mean and median diverge by up to **47%**:

| bench | framework | mean | median |
|---|---|---|---|
| 1 item, 1k updates | vue | 14.8 | **10.0** |
| fan-out single burst | ember | 25.1 | **17.5** |
| 1 item, 1k updates | angular | 7.8 | **6.1** |

That is enough to reorder a row. On the single-burst fan-out bench, four of ember's ten samples land ~18ms above the other six — an idle-callback scheduling quantum, not framework work:

```
ember  15.0 15.9 16.7 17.1 17.2 17.9 | 36.0 37.6 38.7 38.9
vue    16.5 17.1 17.3 17.8 17.8 17.9 18.0 19.4 19.7 21.8
```

By **mean**: ember 25.1, vue 18.3 — ember reads 37% slower.
By **median**: ember 17.55, vue 17.85 — ember is marginally *faster*.

And the boxplot on the same page already drew the median, so the table and the chart disagreed about who won.

## What this does

- **p50 (the median) is the default** — and yes, median == p50
- **p50 / p75 / p90 selectable** via `?p=`, on both the tables page (radio group, matching the existing "values" control) and the compare page (a `<select>`, matching its control bar)
- **the table says which one it is**, in the corner cell above the benchmark names, so no cell is ever an unlabelled number

Percentiles run toward the **worse** end of the distribution whichever direction is better, so pXX always reads "XX% of samples came in at least this good" — the slow tail for a duration, the low tail for a frame rate. Without that, p90 would mean tail-risk on the lower-is-better table and best-case on the higher-is-better one.

Interpolated between order statistics (Excel `PERCENTILE.INC` / numpy default), so p50 of an even-sized sample is the midpoint of the middle two — the median as you'd compute it by hand. Verified against known values (`p50 [1,2,3,4] = 2.5`, `p90 [1..10] = 9.1`, `p75 [1..10] = 7.75`).

`TableRow` and `Table` derived their numbers in the *constructor*, which would have ignored the new param — both are `@cached` getters now, so changing the percentile recomputes values, colors, and totals.

Toggling p50 → p90 is also the fastest way to see which benches are quantization-bound: the ones where a framework's number jumps are the ones where the `:done` scheduling slot dominates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)