### PR TITLE
Verify fan-out against the container's text, not 1000 span reads

### DIFF
--- a/common/src/tests/fan-out.js
+++ b/common/src/tests/fan-out.js
@@ -96,21 +96,30 @@ export class FanOut extends BaseTest {
     return `[${item}]`;
   }
 
+  /**
+   * The app's root output. Looked up once; it is never replaced, only the
+   * value rendered inside it changes.
+   *
+   * @type {Element | null}
+   */
+  #output = null;
+
   verify = () => {
-    let spans = document.querySelectorAll('output > span');
-
     if (this.#updateCount !== this.#updates) return false;
-    if (spans.length !== this.#consumers) return false;
 
-    let expected = this.formatItem(this.#last ?? -1);
+    this.#output ??= document.querySelector('output');
 
-    // every consumer must show the final value --
-    // partially-updated DOM does not count as done.
-    for (let span of spans) {
-      if (span.textContent?.trim() !== expected) return false;
-    }
+    if (!this.#output) return false;
 
-    return true;
+    // The finished state is fully known: the final value, once per
+    // consumer. Comparing the container's text against that is one string
+    // (0.07ms at 4x throttle over 1000 consumers) instead of reading all
+    // 1000 spans (0.61ms) -- and this runs inside the measured window.
+    //
+    // Whitespace is stripped because some templates indent their consumers.
+    let expected = this.formatItem(this.#last ?? -1).repeat(this.#consumers);
+
+    return this.#output.textContent?.replace(/\s+/g, '') === expected;
   };
 
   /**


### PR DESCRIPTION
`FanOut.verify` read `textContent` off each of the 1000 consumer spans in turn, allocating 1000 strings every time it ran — inside the measured window, before `:done`.

The finished state is fully known — the final value, once per consumer — so the check is now one comparison of the container's flattened text against exactly that. 0.07ms against 0.61ms at 4x throttle over 1000 consumers. A stale or partially-flushed consumer still changes the flattened text, so the failure mode that matters is caught the same as before.

To answer the thread's question directly: verification only runs after the update loop completes (`#updateCount === #updates` is the first guard) — the re-checks are only for the DOM catching up, and those are what this cost lands on.

`ManyItems.verify` is deliberately left alone: its `document.body.textContent.includes(...)` measures 0.04ms. There was nothing to win.

Verified against vue and angular (the indented-template case): both still reach the verified state.
