### PR TITLE
Verify the whole list, not just the last item written

### DIFF
--- a/common/src/tests/many-items.js
+++ b/common/src/tests/many-items.js
@@ -16,9 +16,20 @@ export class ManyItems extends BaseTest {
   #updateCount = 0;
 
   /**
-   * @type {number | undefined}
+   * Which indices were written to, for the random variants. The sequential
+   * ones are exactly `i < #totalUpdates` and need no bookkeeping, which is
+   * what keeps this off the hot path: the random benches update at most a
+   * few hundred items, the high-count benches are all sequential.
+   *
+   * @type {Set<number> | undefined}
    */
-  #last;
+  #updated;
+
+  /**
+   * @type {string | undefined}
+   */
+  #expected;
+
   /**
    * @type {number}
    */
@@ -32,6 +43,7 @@ export class ManyItems extends BaseTest {
 
     this.#totalUpdates = totalUpdates ?? -1;
     this.#random = random;
+    this.#updated = random ? new Set() : undefined;
     this.#percentRandomAwait = qpPercent('percentRandomAwait', 0);
   }
 
@@ -44,19 +56,57 @@ export class ManyItems extends BaseTest {
    * Using the square brackets, [,], we ensure that items
    * running in to each other can still uniquely be .include() checked.
    *
-   * @param {number} item
+   * `undefined` is what an item that has not been updated yet renders as --
+   * `getData` fills the list with it -- so it is part of the signature.
+   *
+   * @param {number | undefined} item
    */
   formatItem(item) {
     return `[${item}]`;
   }
 
+  /**
+   * Whether index `i` should be showing its own value by now.
+   *
+   * @param {number} i
+   */
+  #wasUpdated(i) {
+    return this.#updated ? this.#updated.has(i) : i < this.#totalUpdates;
+  }
+
+  /**
+   * Every item in the state the run should have left it in, as one string.
+   */
+  #expectedText() {
+    let text = '';
+
+    for (let i = 0; i < this.#num; i++) {
+      text += this.formatItem(this.#wasUpdated(i) ? i : undefined);
+    }
+
+    return text;
+  }
+
   verify = () => {
-    let result = document.body.textContent?.trim() ?? '';
+    if (this.#updateCount !== this.#totalUpdates) return false;
 
-    let didRunEverything = this.#updateCount === this.#totalUpdates;
-    let hasCorrectDOM = result.includes(`[${this.#last}]`);
+    // The whole list, not just the last item written.
+    //
+    // This used to ask whether `[#last]` appeared anywhere in the document,
+    // which proves that *one* item rendered. A framework part-way through
+    // flushing satisfies that, so a run could be called done with earlier
+    // updates still pending -- and on the random variants `#last` is an
+    // arbitrary index that may well have been rendered long before the end,
+    // so the check was close to free to pass.
+    //
+    // Compared as a substring rather than for equality so that app chrome
+    // around the list does not matter, and whitespace-stripped because some
+    // templates space their items out and some do not.
+    this.#expected ??= this.#expectedText();
 
-    return didRunEverything && hasCorrectDOM;
+    let rendered = document.body.textContent?.replace(/\s+/g, '') ?? '';
+
+    return rendered.includes(this.#expected);
   };
 
   #randomNextValue = () => {
@@ -85,9 +135,10 @@ export class ManyItems extends BaseTest {
       }
 
       let nextValue = this.#random ? this.#randomNextValue() : i;
+
       set(nextValue);
       this.#updateCount++;
-      this.#last = nextValue;
+      this.#updated?.add(nextValue);
     }
 
     tryVerify(name, this.verify);


### PR DESCRIPTION
`ManyItems.verify` asked whether `[#last]` appeared anywhere in the document. That proves **one** item rendered.

A framework part-way through flushing satisfies it, so a run can be called done with earlier updates still pending. On the random variants it's weaker still: `#last` is an arbitrary index that may have been written — and rendered — long before the loop ended. And because `set(i)` writes `items[i] = i`, re-writing an index produces the same value, so the check can be satisfied by a render that happened hundreds of updates earlier.

With `updates=250` over `items=1000`, the final index collides with an earlier one about 22% of the time.

## What it does now

Compares the whole list against the state the run should have left it in.

Which indices those are is known without any bookkeeping for the sequential variants (`i < #totalUpdates`). The random variants keep a `Set`, which is why it's built *only* when `random` is on — those benches update at most a few hundred items, and every high-count bench (10k, 100k updates) is sequential, so no bookkeeping lands on the hot path.

Compared as a substring rather than for equality so app chrome around the list doesn't matter, and whitespace-stripped because some templates space their items out and some don't.

## Also

`formatItem` now says it takes `number | undefined`. That's what it has always been handed for items that haven't been updated — `getData` fills the list with `undefined` — and the narrower type is what pushed the angular app into writing `test.formatItem(item as number)`.

Verified on the 25%-random variant across ember, vue and solid: all still reach the verified state, in 2 checks, via the mutation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
