### PR TITLE
Seed every workload, and let query params reach the workers at all

### DIFF
--- a/common/src/tests/dbmon/chat-worker.js
+++ b/common/src/tests/dbmon/chat-worker.js
@@ -1,6 +1,6 @@
 let isRunning = false;
 
-import { globalState } from '../utils.js';
+import { DEFAULT_SEED, globalState, qpNum, seededRandom } from '../utils.js';
 
 addEventListener('message', function handleMessage(event) {
   let data = JSON.parse(event.data);
@@ -23,6 +23,13 @@ import { faker } from '@faker-js/faker';
 function start() {
   isRunning = true;
 
+  // faker has its own generator, and unseeded it hands every framework
+  // different names and different message lengths -- which is different text
+  // to lay out, on the bench that measures frame rate
+  faker.seed(qpNum('seed', DEFAULT_SEED));
+
+  const random = seededRandom();
+
   // initial data
   postMessage({
     type: 'json',
@@ -31,7 +38,7 @@ function start() {
   });
 
   async function loop() {
-    let delay = Math.random() * 100;
+    let delay = random() * 100;
     await new Promise((resolve) => setTimeout(resolve, delay));
 
     // TODO: only post what changed

--- a/common/src/tests/dbmon/db-worker.js
+++ b/common/src/tests/dbmon/db-worker.js
@@ -1,6 +1,6 @@
 let isRunning = false;
 
-import { globalState } from '../utils.js';
+import { globalState, seededRandom } from '../utils.js';
 
 addEventListener('message', function handleMessage(event) {
   let data = JSON.parse(event.data);
@@ -23,6 +23,9 @@ import { generateData } from './env.js';
 function start() {
   isRunning = true;
 
+  // seeded here rather than at module scope: the page's query string, and so
+  // the seed, only arrives with the start message
+  const random = seededRandom();
   let data = generateData();
 
   // initial data
@@ -33,7 +36,7 @@ function start() {
   });
 
   async function loop() {
-    let delay = Math.random() * 15;
+    let delay = random() * 15;
     await new Promise((resolve) => setTimeout(resolve, delay));
 
     let changed = data.updateData();

--- a/common/src/tests/dbmon/env.js
+++ b/common/src/tests/dbmon/env.js
@@ -20,14 +20,20 @@
 //   https://github.com/ryansolid/solid-dbmon/blob/master/dist/ENV.js
 //   https://github.com/html-next/vertical-collection/blob/master/tests/dummy/app/lib/get-data.js
 
-import { qpNum, qpPercent } from '../utils.js';
+import { qpNum, qpPercent, seededRandom } from '../utils.js';
 
 var first = true;
 var counter = 0;
 var data;
 var _base;
-let mutations = qpPercent('mutations', 0.15);
-let rows = qpNum('rows', 20);
+
+// Read in generateData, not here. A worker only learns the page's query
+// string when it is told to start, and that message arrives long after this
+// module is evaluated -- so at import time `mutations` and `rows` were
+// always their defaults, whatever the URL said.
+let random = seededRandom();
+let mutations = 0.15;
+let rows = 20;
 
 function formatElapsed(value) {
   var str = parseFloat(value).toFixed(2);
@@ -67,16 +73,16 @@ function updateQuery(object) {
   if (!object) {
     object = {};
   }
-  var elapsed = Math.random() * 15;
+  var elapsed = random() * 15;
   object.elapsed = elapsed;
   object.formatElapsed = formatElapsed(elapsed);
   object.elapsedClassName = getElapsedClassName(elapsed);
   object.query = 'SELECT blah FROM something';
-  object.waiting = Math.random() < 0.5;
-  if (Math.random() < 0.2) {
+  object.waiting = random() < 0.5;
+  if (random() < 0.2) {
     object.query = '<IDLE> in transaction';
   }
-  if (Math.random() < 0.1) {
+  if (random() < 0.1) {
     object.query = 'vacuum';
   }
   return object;
@@ -98,7 +104,7 @@ function cleanQuery(value) {
 }
 
 function generateRow(object, counter) {
-  var nbQueries = Math.floor(Math.random() * 10 + 1);
+  var nbQueries = Math.floor(random() * 10 + 1);
   if (!object) {
     object = {};
   }
@@ -136,6 +142,10 @@ function generateRow(object, counter) {
 }
 
 export function generateData() {
+  random = seededRandom();
+  mutations = qpPercent('mutations', 0.15);
+  rows = qpNum('rows', 20);
+
   if (!data) {
     data = [];
     for (var i = 1; i <= rows; i++) {
@@ -152,7 +162,7 @@ export function generateData() {
     let changed = [];
     for (var i in data) {
       let row = data[i];
-      if (!row.lastSample || Math.random() < mutations) {
+      if (!row.lastSample || random() < mutations) {
         counter = counter + 1;
 
         generateRow(row, counter);

--- a/common/src/tests/many-items.js
+++ b/common/src/tests/many-items.js
@@ -3,6 +3,7 @@ import {
   qpBool,
   qpNum,
   qpPercent,
+  seededRandom,
   tryVerify,
   yieldKind,
   yieldTo,
@@ -46,6 +47,8 @@ export class ManyItems extends BaseTest {
    * @type {'micro' | 'macro'}
    */
   #yieldKind = yieldKind();
+
+  #rng = seededRandom();
 
   constructor({
     totalUpdates = qpNum('updates', 10_000),
@@ -122,7 +125,7 @@ export class ManyItems extends BaseTest {
   };
 
   #randomNextValue = () => {
-    return Math.floor(Math.random() * this.#num);
+    return Math.floor(this.#rng() * this.#num);
   };
 
   /**
@@ -140,7 +143,7 @@ export class ManyItems extends BaseTest {
       if (this.#percentRandomAwait > 0) {
         if (
           this.#percentRandomAwait < 1 ||
-          Math.random() < this.#percentRandomAwait
+          this.#rng() < this.#percentRandomAwait
         ) {
           await yieldTo(this.#yieldKind);
         }

--- a/common/src/tests/one-item.js
+++ b/common/src/tests/one-item.js
@@ -1,4 +1,11 @@
-import { qpNum, qpPercent, tryVerify, yieldKind, yieldTo } from './utils.js';
+import {
+  qpNum,
+  qpPercent,
+  seededRandom,
+  tryVerify,
+  yieldKind,
+  yieldTo,
+} from './utils.js';
 import { RUN, BaseTest } from './base-test.js';
 
 /**
@@ -22,6 +29,8 @@ export class OneItem extends BaseTest {
    * @type {'micro' | 'macro'}
    */
   #yieldKind = yieldKind();
+
+  #random = seededRandom();
 
   /**
    * @type {number}
@@ -82,7 +91,7 @@ export class OneItem extends BaseTest {
       if (this.#percentRandomAwait > 0) {
         if (
           this.#percentRandomAwait < 1 ||
-          Math.random() < this.#percentRandomAwait
+          this.#random() < this.#percentRandomAwait
         ) {
           await yieldTo(this.#yieldKind);
         }

--- a/common/src/tests/utils.js
+++ b/common/src/tests/utils.js
@@ -96,6 +96,49 @@ export function yieldTo(kind) {
   return kind === 'macro' ? nextMacrotask() : Promise.resolve();
 }
 
+/**
+ * Changing this changes every workload, so runs recorded either side of it
+ * are not comparable. Override per run with `?seed=`.
+ */
+export const DEFAULT_SEED = 1;
+
+/**
+ * A seeded stand-in for `Math.random`.
+ *
+ * The benches lean on randomness in a lot of places -- which items a random
+ * variant updates, which rows dbmon mutates and what it puts in them, how
+ * long each worker sleeps, what text faker generates. All of it came from
+ * `Math.random`, so every framework was measured against a *different*
+ * workload, and so was every run of the same framework. Seeding it means
+ * every framework does identical work, and a suspicious result can be
+ * reproduced instead of re-rolled.
+ *
+ * The algorithm is mulberry32, by Tommy Ettinger, copied verbatim from
+ * bryc's collection of seedable PRNGs (public domain):
+ * https://github.com/bryc/code/blob/master/jshash/PRNGs.md#mulberry32
+ * That page also covers how it works and how it compares to alternatives.
+ * Tiny, fast, and good enough for picking indices and delays.
+ *
+ * Each caller gets its own stream so that adding a call site in one place
+ * does not shift the sequence everywhere else.
+ *
+ * @param {number} [seed]
+ * @returns {() => number}
+ */
+export function seededRandom(seed = qpNum('seed', DEFAULT_SEED)) {
+  let a = seed >>> 0;
+
+  return function random() {
+    a = (a + 0x6d2b79f5) | 0;
+
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 const state = Symbol.for('worker:state');
 
 export function globalState() {
@@ -108,7 +151,11 @@ export function globalState() {
  * @param {string} name
  */
 export function qp(name) {
-  let search = globalThis.location?.search ?? globalState()?.search;
+  // A worker has a `location`, but it is the worker script's own URL and its
+  // search is the empty string -- which `??` does not fall through, so the
+  // search the page forwarded on startup was never consulted and no query
+  // param has ever reached a worker. `||` falls through to it.
+  let search = globalThis.location?.search || globalState()?.search || '';
 
   let query = new URLSearchParams(search);
 


### PR DESCRIPTION
Every source of randomness in the benches came from `Math.random`: which items a random variant updates, whether an async variant yields on a given iteration, which dbmon rows mutate and what goes in them, how long each worker sleeps between messages, and what text faker generates for the chat.

So **every framework was measured against a different workload**, and so was every run of the same framework. On the random variants that's a different set of items; on dbmon it's a different mutation rate, a different message cadence, and different string lengths to lay out — on the one bench that measures frame rate.

Everything now draws from a seeded mulberry32, `?seed=` (default 1). Each caller gets its own stream so adding a call site in one place doesn't shift the sequence everywhere else.

Verified — same seed, same final DOM byte for byte, and the same DOM **across frameworks**, which is the actual claim:

```
ember  seed=1  sha256=96aa11cd7d437fa6
vue    seed=1  sha256=96aa11cd7d437fa6
solid  seed=1  sha256=96aa11cd7d437fa6
ember  seed=2  sha256=82d09869baab7448
```

## Two bugs had to be fixed to get a seed into the workers

Both were silently breaking dbmon's configuration already:

1. **`qp()` never worked in a worker.** It read `globalThis.location?.search ?? globalState()?.search`. A worker *has* a `location` — the worker script's own URL — whose `search` is the empty string, and `??` doesn't fall through an empty string. The search the page forwards on startup was never consulted.
2. **`dbmon/env.js` read `mutations` and `rows` at module scope**, which evaluates at import time — long before the start message arrives with the search. Even with (1) fixed they'd have been defaults.

Together, `?rows=` and `?mutations=` did nothing at all:

| URL | before | after |
|---|---|---|
| (none) | 40 rows | 40 rows |
| `?rows=5` | 40 rows | **10 rows** |
| `?rows=100` | 40 rows | **200 rows** |

## Scope

Seeding fixes the *data*, not the *scheduling* — workers still interleave with the main thread however the OS decides, and dbmon's frame rate still depends on that. But identical data was the half that was in our control, and it's a plausible chunk of the 3–5x max/min spread on the random benches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
