### PR TITLE
Serve with no-store, and reject instead of hanging on a taken port

### DIFF
--- a/src/runner/serve.ts
+++ b/src/runner/serve.ts
@@ -43,13 +43,30 @@ export function serve(directory: string, port = 3000): Promise<http.Server> {
 
       const contentType = mimeTypes[extname] || 'application/octet-stream';
 
-      res.writeHead(200, { 'Content-Type': contentType });
+      res.writeHead(200, {
+        'Content-Type': contentType,
+        /**
+         * Every framework's app is served from this same origin, on this
+         * same port, at this same `/index.html`. Without a cache directive
+         * the browser is free to apply heuristic caching, and a hit across
+         * that boundary means benchmarking one framework's build under
+         * another framework's name.
+         *
+         * Nothing here should be cached anyway: each sample is a fresh page
+         * load and the point is to measure the app, not the transport.
+         */
+        'Cache-Control': 'no-store',
+      });
 
       return res.end(content);
     });
   });
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    // Without this the promise never settles when the port is taken, and
+    // the runner hangs with no output rather than saying what is wrong.
+    server.on('error', reject);
+
     server.listen(port, () => {
       killable(server);
       resolve(server);


### PR DESCRIPTION
Every framework's app is served from the same origin, on the same port 3000, at the same `/index.html` — and the responses carried no cache directive at all, not even a `Last-Modified` to validate against. That leaves the browser free to apply heuristic caching, and a hit across that boundary means benchmarking one framework's build under another framework's name.

Nothing here wants caching: every sample is a fresh page load, and the point is to measure the app rather than the transport.

`server.listen` also had no `error` handler, so the returned promise simply never settled if the port was in use — the runner would hang with no output at all.

Verified both:

```
Cache-Control: no-store
busy port rejects with: EADDRINUSE
```

Independent of the other measurement PRs; applies cleanly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)