### PR TITLE
Reset results under the name the samples are actually written to

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -175,12 +175,16 @@ for (const framework of info.frameworks) {
     for (const bench of info.benches) {
       if (bench.app !== app) continue;
 
-      await prepareForResults(framework, bench, info.filePath);
-
       for (const variant of info.variants) {
         const url = serverUrl + '/?' + bench.query + variant.query;
+        const name = variant.name
+          ? `${bench.name} ${variant.name}`
+          : bench.name;
 
         clack.log.info(`\tVariant: ${url}`);
+
+        // per variant, under the same name addResult writes to
+        await prepareForResults(framework, bench, name, info.filePath);
 
         const count = bench.ignoreCount ? 1 : COUNT;
 
@@ -188,10 +192,6 @@ for (const framework of info.frameworks) {
           clack.log.info(`\t\tRemaining: ${count - i}`);
 
           const performanceMarks = await getMarks(browser, url);
-
-          const name = variant.name
-            ? `${bench.name} ${variant.name}`
-            : bench.name;
 
           await addResult(
             framework,

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -161,14 +161,27 @@ async function getVersion(framework: string, bench: BenchmarkInfo) {
   return version;
 }
 
+/**
+ * Clears out whatever a previous run left under this framework/bench pair,
+ * so appending to an existing file replaces that series rather than
+ * growing it.
+ *
+ * `resultName` rather than `bench.name`: a named variant is recorded as
+ * `"<bench> <variant>"`, which is the key `addResult` writes to. Keying the
+ * reset off the bare bench name meant a variant's samples were never
+ * cleared, and the bare name was cleared without ever being written to.
+ * Dormant while the only variant is the unnamed one, and wrong the moment
+ * the manual-batching variant comes back.
+ */
 export async function prepareForResults(
   framework: string,
   bench: BenchmarkInfo,
+  resultName: string,
   filePath: string,
 ) {
   const existing = await getResults(filePath);
 
-  const benchName = bench.name;
+  const benchName = resultName;
   const version = await getVersion(framework, bench);
 
   existing[framework] ||= {};


### PR DESCRIPTION
`prepareForResults` cleared `results[framework][bench.name]`, but `addResult` writes to `results[framework]["<bench> <variant>"]` whenever the variant has a name.

So for a named variant the reset clears a key nothing ever writes to, and the key that *is* written to is never cleared — appending to an existing results file would keep growing that series instead of replacing it, mixing two runs' samples into one distribution.

Dormant today, because the only variant in the list is the unnamed one. Live again the moment the manual-batching variant is uncommented — which is exactly when nobody would be looking for it.

The name is now composed once, before the loop that uses it, and passed to both.

Independent of the other PRs; applies cleanly to `main`. (The three `tsc` errors under `src/` are pre-existing on `main` — the root `lint` script only runs prettier and eslint there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)