### PR TITLE
Collect marks in one round trip instead of polling the page

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -35,6 +35,13 @@ interface MarkEntry {
   detail?: unknown;
 }
 
+/**
+ * How long a single sample is allowed to take before we stop waiting.
+ * The page gives up on its own at 30s and throws, so reaching this means
+ * something worse than a slow render.
+ */
+const BUDGET_MS = 60_000;
+
 async function getMarks(browser: Browser, url: string) {
   const page = await browser.newPage();
 
@@ -53,45 +60,69 @@ async function getMarks(browser: Browser, url: string) {
   // TODO: is there a way to wait for the page to calmn down?
   await page.waitForNetworkIdle();
 
-  let marks: Array<MarkEntry> = [];
+  const progress = clack.progress({ style: 'light', max: BUDGET_MS });
+  // Node-side only: this ticks the bar without touching the page.
+  const ticking = setInterval(() => progress.advance(100), 100);
 
-  let remainingWaitTime = 60_000; // 1 minute
-
-  const progress = clack.progress({ style: 'light', max: remainingWaitTime });
-
-  while (remainingWaitTime > 0) {
-    const allMarks = await page.evaluate(() => {
-      return performance.getEntriesByType('mark').map((entry) => {
+  /**
+   * One round trip.
+   *
+   * This used to `page.evaluate` every 100ms until `:done` showed up, which
+   * put a protocol-driven task on the main thread of the page being
+   * measured -- and serialized every mark on it -- a few hundred times over
+   * a dbmon run, while that run was measuring how well the page keeps up.
+   *
+   * A PerformanceObserver resolves the moment the mark lands instead, so
+   * the page is touched once at the start and once at the end.
+   */
+  const allMarks = await page.evaluate((budget) => {
+    const read = () =>
+      performance.getEntriesByType('mark').map((entry) => {
         return {
           name: entry.name,
           at: entry.startTime,
           detail: entry.detail,
         };
       });
-    });
 
-    if (allMarks.find((m) => m.name === ':done')) {
-      progress.stop(`Finished`);
-      marks = allMarks.map((entry) => {
-        if (!entry.detail) {
-          delete entry.detail;
-        }
+    return new Promise<ReturnType<typeof read>>((resolve) => {
+      const isDone = () => performance.getEntriesByName(':done').length > 0;
 
-        return entry as MarkEntry;
+      if (isDone()) return resolve(read());
+
+      const observer = new PerformanceObserver(() => {
+        if (!isDone()) return;
+
+        observer.disconnect();
+        resolve(read());
       });
 
-      break;
+      // buffered so a `:done` that landed between `load` and this call is
+      // not missed
+      observer.observe({ type: 'mark', buffered: true });
+
+      setTimeout(() => resolve(read()), budget);
+    });
+  }, BUDGET_MS);
+
+  clearInterval(ticking);
+
+  const finished = allMarks.some((mark) => mark.name === ':done');
+
+  progress.stop(finished ? `Finished` : `Gave up after ${BUDGET_MS}ms`);
+
+  const marks = allMarks.map((entry) => {
+    if (!entry.detail) {
+      delete entry.detail;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    remainingWaitTime -= 100;
-    progress.advance(100);
-  }
+    return entry as MarkEntry;
+  });
 
-  page.close();
+  await page.close();
 
-  if (marks.length === 0) {
-    clack.log.warn(`No marks recorded`);
+  if (!finished) {
+    clack.log.warn(`No :done mark -- this sample did not finish`);
   }
 
   return marks;


### PR DESCRIPTION
`getMarks` ran a `page.evaluate` every 100ms until `:done` appeared. Each one is a protocol-driven task on the main thread of **the page being measured**, and each one serialized every mark on the page back over CDP.

Over a 25s dbmon sample that's ~250 of them, injected into the page while that very page is being scored on how well it keeps up with its workers. The measurement was interfering with the thing it measured — and the interference scaled with how long a sample took, so the slowest frameworks got the most of it.

A `PerformanceObserver` in the page resolves a single `page.evaluate` the moment `:done` lands, so the page is touched once at the start and once at the end. `buffered: true` so a `:done` that landed between `load` and the call isn't missed, and a page-side timeout so a sample that never finishes still returns what it has.

The progress bar stays, ticked from a Node-side interval — a different process, so it costs the page nothing.

Also awaits `page.close()`, which was floating: the next sample could start while the previous page was still tearing down, and for dbmon that page has a rAF loop and two workers still running.

Driven end to end against the real runner (`--framework=ember --bench='1 item, 1k updates' --count=2 --skip-build --headless`) — completes, exit 0, marks recorded in the same shape as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
