### PR TITLE
Stop the browser from throttling the window we are measuring

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -39,8 +39,14 @@ async function getMarks(browser: Browser, url: string) {
   const page = await browser.newPage();
 
   if (CPU_THROTTLE !== 1) {
-    page.emulateCPUThrottling(CPU_THROTTLE);
+    // awaited: this is a CDP round trip, and an un-awaited one is a
+    // floating rejection that could also land after navigation starts
+    await page.emulateCPUThrottling(CPU_THROTTLE);
   }
+
+  // a tab that is not the active one gets its rAF throttled, which is the
+  // whole measurement on the dbmon bench
+  await page.bringToFront();
 
   await page.goto(url, { waitUntil: 'load' });
 
@@ -95,7 +101,26 @@ const browser = await puppeteer.launch({
   executablePath: chromeLocation,
   headless: HEADLESS,
   defaultViewport: { width: 1280, height: 720 },
-  args: ['--window-size=1280,800'],
+  args: [
+    '--window-size=1280,800',
+    /**
+     * Chrome throttles timers, backgrounds renderers, and drops
+     * requestAnimationFrame to a crawl for windows it thinks nobody is
+     * looking at. Headed runs are the default here, so anything the user
+     * puts in front of the benchmark window -- or any occlusion at all --
+     * would otherwise land in the results as a slow framework.
+     */
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    /**
+     * A profile-wide first-run/default-browser prompt, and any extension,
+     * is work the benchmark did not ask for.
+     */
+    '--disable-extensions',
+    '--no-default-browser-check',
+    '--no-first-run',
+  ],
 });
 
 const runStart = Date.now();


### PR DESCRIPTION
Headed is the default here (`--headless` is opt-in), which means the benchmark runs in a real window on a real desktop. Chrome throttles timers, backgrounds renderers, and drops `requestAnimationFrame` to a crawl for windows it decides nobody is looking at — so anything the user puts in front of that window, or any occlusion at all, arrives in the results as a slow framework.

On the dbmon bench, rAF cadence **is** the measurement.

```
--disable-background-timer-throttling
--disable-backgrounding-occluded-windows
--disable-renderer-backgrounding
```

plus `page.bringToFront()` per sample, so a tab that isn't the active one isn't being scored on its throttled frame rate.

Also:

- `--disable-extensions --no-first-run --no-default-browser-check` — work the benchmark didn't ask for
- `page.emulateCPUThrottling` is now awaited. It's a CDP round trip, and an un-awaited one is both a floating rejection and an unstated ordering assumption about a message that has to arrive before navigation.

Driven end to end against the real runner: completes, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
