### PR TITLE
Fail the run when a sample never finishes, instead of recording a hole

### DIFF
--- a/src/runner/arg.ts
+++ b/src/runner/arg.ts
@@ -18,6 +18,7 @@ export const CPU_THROTTLE = int('--cpu-throttle', 1);
 export const FRAMEWORK = str('--framework');
 export const BENCH_NAME = str('--bench');
 export const SKIP_BUILD = bool('--skip-build');
+export const TIMEOUT = int('--timeout', 60_000);
 export const VERSION_OVERRIDES = versionOverrides();
 
 function col1(name: string) {
@@ -52,6 +53,7 @@ console.log(
     ),
     row(col1('--headless'), col2(HEADLESS), col3('limited to 60 fps')),
     row(col1('--count'), col2(COUNT), col3('sample count')),
+    row(col1('--timeout'), col2(TIMEOUT), col3('ms a single sample may take')),
     row(col1('--framework'), col2(FRAMEWORK), col3(`or '${ALL}'`)),
     row(col1('--bench'), col2(BENCH_NAME), col3(`or '${ALL}'`)),
     ...Object.entries(VERSION_OVERRIDES).map(([framework, override]) =>

--- a/src/runner/environment.ts
+++ b/src/runner/environment.ts
@@ -14,6 +14,7 @@ import {
   FRAMEWORK,
   HEADLESS,
   SKIP_BUILD,
+  TIMEOUT,
 } from './arg.ts';
 
 const whichGoogleChrome = await $`which google-chrome`;
@@ -112,6 +113,7 @@ export async function getInfo() {
       COUNT,
       FRAMEWORK,
       BENCH_NAME,
+      TIMEOUT,
     },
     environment: {
       machine: {

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -5,7 +5,7 @@ import * as clack from '@clack/prompts';
 import { $ } from 'execa';
 import puppeteer, { type Browser } from 'puppeteer';
 
-import { COUNT, CPU_THROTTLE, HEADLESS, SKIP_BUILD } from './arg.ts';
+import { COUNT, CPU_THROTTLE, HEADLESS, SKIP_BUILD, TIMEOUT } from './arg.ts';
 import { getBenchInfo } from './bench-info.ts';
 import { chromeLocation } from './environment.ts';
 import {
@@ -35,13 +35,6 @@ interface MarkEntry {
   detail?: unknown;
 }
 
-/**
- * How long a single sample is allowed to take before we stop waiting.
- * The page gives up on its own at 30s and throws, so reaching this means
- * something worse than a slow render.
- */
-const BUDGET_MS = 60_000;
-
 async function getMarks(browser: Browser, url: string) {
   const page = await browser.newPage();
 
@@ -60,7 +53,7 @@ async function getMarks(browser: Browser, url: string) {
   // TODO: is there a way to wait for the page to calmn down?
   await page.waitForNetworkIdle();
 
-  const progress = clack.progress({ style: 'light', max: BUDGET_MS });
+  const progress = clack.progress({ style: 'light', max: TIMEOUT });
   // Node-side only: this ticks the bar without touching the page.
   const ticking = setInterval(() => progress.advance(100), 100);
 
@@ -103,13 +96,13 @@ async function getMarks(browser: Browser, url: string) {
 
       setTimeout(() => resolve(read()), budget);
     });
-  }, BUDGET_MS);
+  }, TIMEOUT);
 
   clearInterval(ticking);
 
   const finished = allMarks.some((mark) => mark.name === ':done');
 
-  progress.stop(finished ? `Finished` : `Gave up after ${BUDGET_MS}ms`);
+  progress.stop(finished ? `Finished` : `Gave up after ${TIMEOUT}ms`);
 
   const marks = allMarks.map((entry) => {
     if (!entry.detail) {
@@ -121,8 +114,23 @@ async function getMarks(browser: Browser, url: string) {
 
   await page.close();
 
+  /**
+   * A sample that never reached `:done` is not a slow sample, it is a
+   * broken one -- the page throws on its own after 30s if the DOM never
+   * settles, so getting here means something worse.
+   *
+   * It used to be recorded anyway, as an entry with no `:done` in it. The
+   * results app skips those with a `console.warn` nobody reads, so a run
+   * could quietly summarize 7 samples while claiming 10, and a run where
+   * every sample failed produced NaN. Stopping is louder and cheaper than
+   * discovering it later; whatever completed before this point is already
+   * in the results file.
+   */
   if (!finished) {
-    clack.log.warn(`No :done mark -- this sample did not finish`);
+    throw new Error(
+      `No :done mark after ${TIMEOUT}ms at ${url}\n` +
+        `Recorded marks: ${marks.map((mark) => mark.name).join(', ') || '(none)'}`,
+    );
   }
 
   return marks;


### PR DESCRIPTION
> **Depends on #59** — and only on #59. It patches the `getMarks` that #59 rewrites, so it cannot stand alone. Everything else in this series is now independent.

A sample that never reached `:done` was recorded anyway, as an entry with no `:done` in it. Nothing downstream treats that as a problem — the results app skips it with a `console.warn` nobody reads — so a run could quietly summarize 7 samples while presenting itself as 10, and a series where every sample failed came out as `NaN`.

A sample that doesn't finish isn't a slow sample, it's a broken one. (With #52 the page gives up on its own after 30s and throws, so reaching the runner's budget means something worse than a slow render.) It now throws, with the URL and the marks it did see. Everything recorded before that point is already in the results file.

The budget is `--timeout` (default 60000, unchanged), and it's recorded in the results file alongside the other args — a run made with a short budget isn't the same run.

Verified both ways:

```
--bench='1 item, 1k updates'                 -> exit 0
--bench='DB Monitor ...' --timeout=2000
  Error: No :done mark after 2000ms at http://localhost:3000/?
  Recorded marks: :start
                                             -> exit 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
