### PR TITLE
Stop --bench from emptying the framework list

### DIFF
--- a/src/runner/repo.ts
+++ b/src/runner/repo.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { ALL, BENCH_NAME, FRAMEWORK } from './arg.ts';
+import { ALL, FRAMEWORK } from './arg.ts';
 
 export async function getTests() {
   /**
@@ -19,10 +19,13 @@ export async function getTests() {
     results = results.filter((result) => result.includes(`/${FRAMEWORK}/`));
   }
 
-  if (BENCH_NAME && BENCH_NAME !== ALL) {
-    results = results.filter((result) => result.includes(`${BENCH_NAME}`));
-  }
-
+  /**
+   * Deliberately not filtered by `--bench`. These paths are app *folders*
+   * (`one-item-many-updates`), and `--bench` takes a benchmark's display
+   * name (`1 item, 1k updates`) -- the two never match, so filtering on it
+   * emptied the list. The framework list should not depend on which
+   * benchmark is selected either way.
+   */
   return results;
 }
 


### PR DESCRIPTION
Found while testing the runner, not from reading it.

`getTests` filtered app folders by `--bench`, but those paths are folder names (`one-item-many-updates`) and `--bench` takes a benchmark's *display* name (`1 item, 1k updates`). They never match, so the filter removed everything and the `frameworks` set came out empty.

`getFrameworks` reads that set only for `--framework=all`, so the failure was quiet and specific:

```
pnpm bench --framework=all --bench='1 item, 1k updates'
  -> Starting Benchmark Runs
  -> Total: 0.0s
  -> exit 0
```

No frameworks, no servers, no samples — a results file with an empty `results` object, and a successful exit.

`--framework=<one>` was unaffected, because that path returns the name it was given rather than consulting the set. That's why this survived: the two flags are only broken *together*, and only in the `all` direction.

The framework list shouldn't depend on which benchmark is selected in any case, so the filter is gone rather than corrected.

Verified: before, zero frameworks; after, it enumerates all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
