### PR TITLE
Interleave frameworks within each sample round

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -175,12 +175,16 @@ for (const framework of info.frameworks) {
     for (const bench of info.benches) {
       if (bench.app !== app) continue;
 
-      await prepareForResults(framework, bench, info.filePath);
-
       for (const variant of info.variants) {
         const url = serverUrl + '/?' + bench.query + variant.query;
+        const name = variant.name
+          ? `${bench.name} ${variant.name}`
+          : bench.name;
 
         clack.log.info(`\tVariant: ${url}`);
+
+        // per variant, under the same name addResult writes to
+        await prepareForResults(framework, bench, name, info.filePath);
 
         const count = bench.ignoreCount ? 1 : COUNT;
 
@@ -188,10 +192,6 @@ for (const framework of info.frameworks) {
           clack.log.info(`\t\tRemaining: ${count - i}`);
 
           const performanceMarks = await getMarks(browser, url);
-
-          const name = variant.name
-            ? `${bench.name} ${variant.name}`
-            : bench.name;
 
           await addResult(
             framework,

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -140,19 +140,28 @@ clack.log.info('Starting Benchmark Runs');
 
 const benchmarkStart = Date.now();
 
-for (const framework of info.frameworks) {
-  clack.log.info(`Benchmarking ${framework}`);
+/**
+ * One server per framework for the app under test, all up at once.
+ *
+ * That is what lets the sample loop go framework-by-framework *inside* each
+ * round rather than running a framework's whole suite before starting the
+ * next one. A full suite is many minutes of sustained load, and a CPU that
+ * has been at it for ten minutes is not the CPU the first framework was
+ * measured on -- thermal headroom and boost residency both drift one way.
+ * Grouping by framework turned that drift into a per-framework offset;
+ * interleaving spreads it evenly over all of them.
+ */
+async function serversFor(app: string) {
+  const servers = [];
 
-  /**
-   * Iterating on the apps allows us to boot one server for a whose suite of tests
-   */
-  for (const app of info.apps) {
+  for (const framework of info.frameworks) {
     const dir = join('frameworks', framework, app);
 
-    clack.log.info(`Starting server for ${app} in ${dir}/dist`);
+    clack.log.info(`Starting server for ${framework}/${app} in ${dir}/dist`);
 
+    // port 0: the OS picks a free one, so N frameworks can be up together
     // TODO: make the output directory configurable
-    const server = await serve(`${dir}/dist`);
+    const server = await serve(`${dir}/dist`, 0);
     const address = server.address();
 
     assert(
@@ -160,38 +169,51 @@ for (const framework of info.frameworks) {
       `Server for ${framework}, (in ${app}) does not have an address!`,
     );
 
-    const serverUrl =
+    const url =
       typeof address === 'string'
         ? address
         : `http://${address.address === '::' ? 'localhost' : address.address}:${address.port}`;
 
-    clack.log.info(`Server up at ${serverUrl}`);
+    clack.log.info(`  ${framework} up at ${url}`);
 
-    if (!info.benches) {
-      clack.log.error(`No benches selected`);
-      process.exit(1);
-    }
+    servers.push({ framework, server, url });
+  }
 
-    for (const bench of info.benches) {
-      if (bench.app !== app) continue;
+  return servers;
+}
 
-      for (const variant of info.variants) {
-        const url = serverUrl + '/?' + bench.query + variant.query;
-        const name = variant.name
-          ? `${bench.name} ${variant.name}`
-          : bench.name;
+if (!info.benches) {
+  clack.log.error(`No benches selected`);
+  process.exit(1);
+}
 
-        clack.log.info(`\tVariant: ${url}`);
+for (const app of info.apps) {
+  const servers = await serversFor(app);
 
+  for (const bench of info.benches) {
+    if (bench.app !== app) continue;
+
+    for (const variant of info.variants) {
+      const name = variant.name ? `${bench.name} ${variant.name}` : bench.name;
+      const count = bench.ignoreCount ? 1 : COUNT;
+
+      clack.log.info(`${name}`);
+
+      for (const { framework } of servers) {
         // per variant, under the same name addResult writes to
         await prepareForResults(framework, bench, name, info.filePath);
+      }
 
-        const count = bench.ignoreCount ? 1 : COUNT;
+      for (let i = 0; i < count; i++) {
+        clack.log.info(`\tSample ${i + 1} of ${count}`);
 
-        for (let i = 0; i < count; i++) {
-          clack.log.info(`\t\tRemaining: ${count - i}`);
+        for (const { framework, url } of servers) {
+          clack.log.info(`\t\t${framework}`);
 
-          const performanceMarks = await getMarks(browser, url);
+          const performanceMarks = await getMarks(
+            browser,
+            url + '/?' + bench.query + variant.query,
+          );
 
           await addResult(
             framework,
@@ -203,18 +225,21 @@ for (const framework of info.frameworks) {
         }
       }
     }
-
-    const promise = new Promise((resolve) => {
-      server.on('close', resolve);
-    });
-
-    // We add this via the killable package
-    // @ts-expect-error
-    server.kill();
-
-    clack.log.info(`Waiting for server to exit`);
-    await promise;
   }
+
+  clack.log.info(`Waiting for servers to exit`);
+
+  await Promise.all(
+    servers.map(({ server }) => {
+      const closed = new Promise((resolve) => server.on('close', resolve));
+
+      // We add this via the killable package
+      // @ts-expect-error
+      server.kill();
+
+      return closed;
+    }),
+  );
 }
 
 const now = Date.now();

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -161,14 +161,27 @@ async function getVersion(framework: string, bench: BenchmarkInfo) {
   return version;
 }
 
+/**
+ * Clears out whatever a previous run left under this framework/bench pair,
+ * so appending to an existing file replaces that series rather than
+ * growing it.
+ *
+ * `resultName` rather than `bench.name`: a named variant is recorded as
+ * `"<bench> <variant>"`, which is the key `addResult` writes to. Keying the
+ * reset off the bare bench name meant a variant's samples were never
+ * cleared, and the bare name was cleared without ever being written to.
+ * Dormant while the only variant is the unnamed one, and wrong the moment
+ * the manual-batching variant comes back.
+ */
 export async function prepareForResults(
   framework: string,
   bench: BenchmarkInfo,
+  resultName: string,
   filePath: string,
 ) {
   const existing = await getResults(filePath);
 
-  const benchName = bench.name;
+  const benchName = resultName;
   const version = await getVersion(framework, bench);
 
   existing[framework] ||= {};


### PR DESCRIPTION
> **Depends on #58** — and only on #58. The restructured loop calls the 4-arg `prepareForResults` that #58 introduces. Everything else in this series is now independent.

The runner benchmarked one framework's entire suite before starting the next one. A full run is many minutes of sustained load, and the CPU that runs the sixth framework isn't the CPU that ran the first — thermal headroom and boost residency both drift one way over a run like that. Any such drift landed as a **per-framework offset**, in whatever order the frameworks happened to be listed.

Now every framework's server for the app under test is up at once, and the sample loop goes round-by-round:

```
Sample 1 of 3       Sample 2 of 3       Sample 3 of 3
  angular             angular             angular
  ember               ember               ember
  react               react               react
  solid               solid               solid
  svelte              svelte              svelte
  vue                 vue                 vue
```

so the drift is spread evenly instead of accumulating against whoever went last.

Servers bind port 0, so the OS hands out free ports and N of them can be up together rather than all contending for 3000. They're closed together at the end of each app.

Verified end to end: all six frameworks, 3 samples, interleaved exactly as above, exit 0, 10.4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
