### PR TITLE
Read the FPS sample from the frame times, not back out of the overlay

### DIFF
--- a/common/src/fps.js
+++ b/common/src/fps.js
@@ -6,30 +6,26 @@
  * - averages over 1s and 5s, rather than since last frame
  * - precision displayed to 1 decimal place instead of 6
  * - padding to 5 characters to prevent jitter
+ * - samples are read from the frame timestamps directly, not parsed back
+ *   out of the overlay's rendered text (which is repainted at most every
+ *   50ms and rounded to 1 decimal place)
  */
 
 const ms_1s = 1000;
 const ms_5s = 5000;
 
+/**
+ * Frame timestamps of the last 5 seconds, maintained by {@link setupFPS}.
+ *
+ * @type {number[]}
+ */
+let frameTimes = [];
+
+/**
+ * The average frame rate over the last 5 seconds.
+ */
 export function get5sAverage() {
-  let fps = document.getElementById('fps');
-
-  if (!fps) {
-    throw new Error(`FPS was not rendered. First call setupFPS()`);
-  }
-
-  let content = fps.textContent;
-  let lines = content.split('\n');
-  let relevantLine = lines.find((line) => line.includes('5s avg '));
-
-  if (!relevantLine) {
-    throw new Error(`Could not find 5s avg in the FPS element`);
-  }
-
-  let valueStr = relevantLine.replace('5s avg', '').trim();
-  let value = parseFloat(valueStr);
-
-  return value;
+  return rollingAvg(frameTimes, ms_5s, 0);
 }
 
 /**
@@ -75,8 +71,8 @@ export function setupFPS() {
   el.style.height = 'auto';
   document.body.appendChild(el);
 
-  /** @type {number[]} */
-  const frameTimes = [];
+  frameTimes = [];
+
   /** @type {number | undefined} */
   let prevTime;
   /** @type {number | undefined} */


### PR DESCRIPTION
`get5sAverage` found the `#fps` element, split its rendered text on newlines, found the `"5s avg"` line, and `parseFloat`'d it. The overlay repaints at most every 50ms and rounds to one decimal place, so the recorded sample was up to 50ms stale and quantized to the display string — and it threw if the element was restyled.

The frame timestamps now live at module scope; `get5sAverage` computes the same 5s rolling average from them directly, and the overlay renders from the same array.

**Same metric, same units, same direction** — the `fps` mark still carries the 5s average, `bench-info.ts` is untouched, and the dbmon bench file is untouched. Only the path from measurement to number changed. One file, +16/−20.

Verified end to end: `fps: 50.3, 51.2, 52.8, 54.4, 57.4` (headless, 4x throttle).

The worst-frames idea from the earlier revisions is out of this PR. If it's wanted, it should be a deliberate change to how fps is calculated, proposed on its own.
