### PR TITLE
Format each fan-out consumer's value the way the other five apps do

### DIFF
--- a/frameworks/angular/fan-out/src/app/app.ts
+++ b/frameworks/angular/fan-out/src/app/app.ts
@@ -1,4 +1,4 @@
-import { afterNextRender, ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { helpers } from 'common';
 
 const test = helpers.fanOut();
@@ -9,7 +9,7 @@ const test = helpers.fanOut();
   template: `
     <output>
       @for (c of consumers; track c) {
-        <span>{{ formatted() }}</span>
+        <span>{{ format(value()) }}</span>
       }
     </output>
   `,
@@ -17,7 +17,7 @@ const test = helpers.fanOut();
 export class App {
   protected readonly consumers = test.consumerRange;
   protected readonly value = signal(test.getData());
-  protected readonly formatted = computed(() => test.formatItem(this.value()));
+  protected readonly format = (v: number) => test.formatItem(v);
 
   constructor() {
     afterNextRender(() => {


### PR DESCRIPTION
The angular app hoisted `formatItem` into a `computed()`, so it ran **once per render** where react, vue, solid, svelte and ember all run it **once per consumer** — 1000 times per render, on the bench that is specifically about what it costs to update many consumers of one value.

**This is a consistency change, not a performance correction.** I expected the memoization to be worth something, and measured it before touching it. It isn't.

Angular, 4x throttle, 6 runs, median:

| | bursts of 100 | single burst |
|---|---|---|
| `computed` (1 call per render) | 478.4 | 28.85 |
| per consumer (like the others) | **441.9** | **14.6** |

Removing it is neutral-to-faster, so this isn't stacking anything against angular — reading a memoized signal 1000 times is not cheaper than calling a template literal 1000 times. The single-burst samples are noisy enough (11.7 → 30.3 across runs) that the honest read is "no measurable difference".

The reason to make the change is that all six apps should be doing the same work when the bench is about how much that work costs.

Independent of the other PRs; applies cleanly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)