### PR TITLE
Key the ember ten-k list by index, like the other position-keyed apps

### DIFF
--- a/frameworks/ember/ten-k-items-one-time/app/templates/application.gts
+++ b/frameworks/ember/ten-k-items-one-time/app/templates/application.gts
@@ -18,11 +18,18 @@ export default class Test extends Component {
     });
   };
 
+  // key="@index": position-keyed, like react's key={index}, vue and
+  // svelte's positional defaults, and angular's track $index. The default
+  // (@identity) keys by value, and this bench's values change on every
+  // update -- so every update tore its row down and built a new one
+  // (10k adds + 10k removes per flush) instead of writing the text in
+  // place. 3.4x on this bench.
+  //
   // No spaces, like all the other frameworks (especially JSX)
   // Adding invisible characters is so annoying in JSX haha
   //
   // Ember should probably have a way to strip the unmeaning spaces anyway
   // I think the algo is easy
   // prettier-ignore
-  <template>{{#each this.items as |item|}}{{test.formatItem item}}{{/each}}{{(this.start)}}</template>
+  <template>{{#each this.items key="@index" as |item|}}{{test.formatItem item}}{{/each}}{{(this.start)}}</template>
 }


### PR DESCRIPTION
Follow-up from the "why does ember have 2x the mutation records" question. Splitting the update flush's MutationRecords by type showed the apps aren't doing the same *kind* of DOM work on this bench:

| app | keying | flush records (10k items / 10k updates) |
|---|---|---|
| ember | no key → `@identity` | 20,002 `childList` (10k added + 10k removed) |
| vue | positional `v-for` | 10,000 `characterData` |

Ember tore down and recreated every text node; vue rewrites each in place. `{{#each}}` defaults to `@identity`, and this bench's values *are* their identities — every update changes `items[i]` from `undefined` to `i`, so every entry's identity changes and the each treats it as remove + insert.

`key="@index"` keys by position, which is what the majority already does: react keys by index explicitly (with a comment saying so), vue and svelte use positional defaults, angular tracks `$index`. With it, ember's flush becomes byte-identical in shape to vue's — 10,000 `characterData`, 2 `childList` — and:

| 10k items / 10k updates, 4x throttle | median |
|---|---|
| `@identity` (before) | 965.1ms |
| `@index` (after) | **277.6ms** (3.4x) |

## Why solid is left alone

Solid is the other value-keyed app (`<For>` keys referentially; its flush shape is the same 20k `childList`). I built and measured the position-keyed version — solid 2 folded `<Index>` into `<For keyed={false}>`, and the child has to return JSX rather than a bare string or the row text is computed once and never again (the primitive itself works; verified `mapArray` with `keyed: false` updates rows in place in a Node test).

But in `2.0.0-beta.21` it loses:

- the renderer still **replaces the text node per update** — flush shape stays 20k `childList`, zero `characterData`
- `mapArray`'s `keyed: false` diff walks the whole common prefix calling `setSignal` on every row on **every** flush, so the one-update-per-flush async variant regresses 40%: **1539.7ms → 2150ms** median (sync 10k was flat: 199.9 → 186.4)

A change labelled "fairness" shouldn't ship as a measured regression with no DOM benefit, so solid keeps `<For>` for now. Might be worth raising upstream — an O(rows) signal-write pass per flush in the `keyed: false` path looks unintentional, and text-node replacement where `.data` assignment would do may also be beta-transitional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)