### PR TITLE
Fix Solid 2 benchmark update paths

### DIFF
--- a/frameworks/solid/dbmon-with-chat/package.json
+++ b/frameworks/solid/dbmon-with-chat/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.27",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.27"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.17"
   }
 }

--- a/frameworks/solid/dbmon-with-chat/pnpm-lock.yaml
+++ b/frameworks/solid/dbmon-with-chat/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
+        specifier: 3.0.0-next.17
+        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
 
 packages:
 
@@ -118,42 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
+    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.31':
+    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -386,36 +388,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -443,13 +451,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.27':
+    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.27':
+    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -469,11 +477,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.27:
+    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -598,24 +606,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -684,8 +696,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.27:
+    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -715,13 +727,13 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.17:
+    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
@@ -898,7 +910,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -908,36 +920,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.31':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -1130,13 +1142,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.27': {}
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1168,12 +1180,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1358,9 +1370,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.27:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.27
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1387,16 +1399,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3)):
+  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.31
+      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
       vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
     transitivePeerDependencies:

--- a/frameworks/solid/dbmon-with-chat/src/App.tsx
+++ b/frameworks/solid/dbmon-with-chat/src/App.tsx
@@ -1,6 +1,6 @@
 import 'common/dbmon.css';
 import './layout.css';
-import { createEffect, createSignal, For } from 'solid-js';
+import { createSignal, For, onSettled } from 'solid-js';
 import { helpers, type DBRow, type ChatMessage, type DBUpdate, type ChatUpdate } from 'common';
 
 const test = helpers.dbMonWithChat();
@@ -9,9 +9,7 @@ function App() {
   const [db, setDb] = createSignal<Map<string, DBRow>>(new Map());
   const [chats, setChats] = createSignal<ChatMessage[]>([]);
 
-  // no more onMount in solid 2: an effect with an empty compute runs
-  // once after the first render
-  createEffect(() => {}, () => {
+  onSettled(() => {
     test.doit({
       handleDbUpdate: (eventData: DBUpdate) => {
         setDb(prev => {

--- a/frameworks/solid/dbmon-with-chat/src/App.tsx
+++ b/frameworks/solid/dbmon-with-chat/src/App.tsx
@@ -42,21 +42,21 @@ function App() {
           </tr>
         </thead>
         <tbody>
-          <For each={[...db().values()]}>
+          <For each={[...db().values()]} keyed={row => row.dbname}>
             {(row) => (
               <tr>
-                <td class="dbname">{row.dbname}</td>
+                <td class="dbname">{row().dbname}</td>
                 <td class="query-count">
-                  <span class={row.lastSample.countClassName}>
-                    {row.lastSample.queries.length}
+                  <span class={row().lastSample.countClassName}>
+                    {row().lastSample.queries.length}
                   </span>
                 </td>
-                <For each={row.lastSample.topFiveQueries}>
+                <For each={row().lastSample.topFiveQueries} keyed={false}>
                   {(query) => (
                     <td>
-                      {query.elapsed}
+                      {query().elapsed}
                       <div class="popover bottom">
-                        <div class="popover-content">{query.query}</div>
+                        <div class="popover-content">{query().query}</div>
                         <div class="arrow"></div>
                       </div>
                     </td>

--- a/frameworks/solid/fan-out/package.json
+++ b/frameworks/solid/fan-out/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.27",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.27"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.17"
   }
 }

--- a/frameworks/solid/fan-out/pnpm-lock.yaml
+++ b/frameworks/solid/fan-out/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.17
+        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,42 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
+    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.31':
+    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -230,36 +232,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -287,13 +295,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.27':
+    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.27':
+    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -313,11 +321,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.27:
+    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -437,24 +445,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -523,8 +535,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.27:
+    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -554,13 +566,13 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.17:
+    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
@@ -737,7 +749,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -747,36 +759,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.31':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -891,13 +903,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.27': {}
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -929,12 +941,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1089,9 +1101,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.27:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.27
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1118,16 +1130,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.31
+      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
       vite: 8.1.5(@types/node@24.13.3)
       vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:

--- a/frameworks/solid/fan-out/src/App.tsx
+++ b/frameworks/solid/fan-out/src/App.tsx
@@ -11,7 +11,9 @@ function App() {
   });
 
   return <output>
-    <For each={test.consumerRange}>{() => <span>{test.formatItem(value())}</span>}</For>
+    <For each={test.consumerRange}>
+      {() => <span textContent={test.formatItem(value())} />}
+    </For>
   </output>
 }
 

--- a/frameworks/solid/fan-out/src/App.tsx
+++ b/frameworks/solid/fan-out/src/App.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, For } from 'solid-js'
+import { createSignal, For, onSettled } from 'solid-js'
 import { helpers } from 'common';
 
 let test = helpers.fanOut();
@@ -6,14 +6,9 @@ let test = helpers.fanOut();
 function App() {
   const [value, setValue] = createSignal(test.getData())
 
-  // no more onMount in solid 2: an effect with an empty compute runs
-  // once after the first render
-  createEffect(
-    () => {},
-    () => {
-      test.doit((v: number) => setValue(v));
-    },
-  );
+  onSettled(() => {
+    test.doit((v: number) => setValue(v));
+  });
 
   return <output>
     <For each={test.consumerRange}>{() => <span>{test.formatItem(value())}</span>}</For>

--- a/frameworks/solid/incrementing-render-effect/package.json
+++ b/frameworks/solid/incrementing-render-effect/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.27",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.27"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.17"
   }
 }

--- a/frameworks/solid/incrementing-render-effect/pnpm-lock.yaml
+++ b/frameworks/solid/incrementing-render-effect/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.17
+        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,42 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
+    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.31':
+    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -230,36 +232,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -287,13 +295,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.27':
+    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.27':
+    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -313,11 +321,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.27:
+    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -437,24 +445,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -523,8 +535,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.27:
+    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -554,13 +566,13 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.17:
+    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
@@ -737,7 +749,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -747,36 +759,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.31':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -891,13 +903,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.27': {}
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -929,12 +941,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1089,9 +1101,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.27:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.27
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1118,16 +1130,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.31
+      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
       vite: 8.1.5(@types/node@24.13.3)
       vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:

--- a/frameworks/solid/incrementing-render-effect/src/App.tsx
+++ b/frameworks/solid/incrementing-render-effect/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect } from 'solid-js'
+import { createSignal, createEffect, onSettled } from 'solid-js'
 import { helpers } from 'common';
 
 const test = helpers.incrementingRenderEffect();
@@ -18,9 +18,7 @@ function App() {
     },
   );
 
-  // no more onMount in solid 2: an effect with an empty compute runs
-  // once after the first render
-  createEffect(() => {}, () => {
+  onSettled(() => {
     test.doit({
       element: el,
       get: () => output(),

--- a/frameworks/solid/incrementing-render-effect/src/App.tsx
+++ b/frameworks/solid/incrementing-render-effect/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
     });
   });
 
-  return <output ref={el}>{output()}</output>;
+  return <output ref={el} textContent={output()} />;
 }
 
 export default App

--- a/frameworks/solid/one-item-many-updates/package.json
+++ b/frameworks/solid/one-item-many-updates/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.27",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.27"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.17"
   }
 }

--- a/frameworks/solid/one-item-many-updates/pnpm-lock.yaml
+++ b/frameworks/solid/one-item-many-updates/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.17
+        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,42 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
+    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.31':
+    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -230,36 +232,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -287,13 +295,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.27':
+    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.27':
+    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -313,11 +321,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.27:
+    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -437,24 +445,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -523,8 +535,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.27:
+    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -554,13 +566,13 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.17:
+    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
@@ -737,7 +749,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -747,36 +759,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.31':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -891,13 +903,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.27': {}
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -929,12 +941,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1089,9 +1101,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.27:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.27
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1118,16 +1130,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.31
+      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
       vite: 8.1.5(@types/node@24.13.3)
       vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:

--- a/frameworks/solid/one-item-many-updates/src/App.tsx
+++ b/frameworks/solid/one-item-many-updates/src/App.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal } from 'solid-js'
+import { createSignal, onSettled } from 'solid-js'
 import { helpers } from 'common';
 
 let test = helpers.oneItem10kUpdates();
@@ -6,9 +6,7 @@ let test = helpers.oneItem10kUpdates();
 function App() {
   const [count, setCount] = createSignal(test.getData())
 
-  // no more onMount in solid 2: an effect with an empty compute runs
-  // once after the first render
-  createEffect(() => {}, () => {
+  onSettled(() => {
     test.doit((i) => setCount(i));
   });
 

--- a/frameworks/solid/one-item-many-updates/src/App.tsx
+++ b/frameworks/solid/one-item-many-updates/src/App.tsx
@@ -10,7 +10,7 @@ function App() {
     test.doit((i) => setCount(i));
   });
 
-  return <output>{test.formatItem(count())}</output>
+  return <output textContent={test.formatItem(count())} />
 }
 
 export default App

--- a/frameworks/solid/ten-k-items-one-time/package.json
+++ b/frameworks/solid/ten-k-items-one-time/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.27",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.27"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.14"
+    "vite-plugin-solid": "3.0.0-next.17"
   }
 }

--- a/frameworks/solid/ten-k-items-one-time/pnpm-lock.yaml
+++ b/frameworks/solid/ten-k-items-one-time/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.27
+        version: 2.0.0-beta.27
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.17
+        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,42 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
+    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.31':
+    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -230,36 +232,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -287,13 +295,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.27':
+    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.27':
+    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -313,11 +321,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.27:
+    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.27
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -437,24 +445,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -523,8 +535,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.27:
+    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -554,13 +566,13 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.17:
+    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
@@ -737,7 +749,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -747,36 +759,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.31':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -891,13 +903,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.27': {}
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -929,12 +941,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1089,9 +1101,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.27:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.27
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1118,16 +1130,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.31
+      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.27
       vite: 8.1.5(@types/node@24.13.3)
       vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:

--- a/frameworks/solid/ten-k-items-one-time/src/App.tsx
+++ b/frameworks/solid/ten-k-items-one-time/src/App.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createStore, Repeat } from 'solid-js'
+import { createStore, onSettled, Repeat } from 'solid-js'
 import { helpers } from 'common';
 
 const test = helpers.tenKitems1UpdateEach();
@@ -6,11 +6,9 @@ const test = helpers.tenKitems1UpdateEach();
 function App() {
   const [store, setStore] = createStore({ items: test.getData() });
 
-  // no more onMount in solid 2: an effect with an empty compute runs
-  // once after the first render.
   // (v1 wrapped test.run in `batch`; solid 2 batches automatically,
   // so plain doit matches the other frameworks again)
-  createEffect(() => {}, () => {
+  onSettled(() => {
     test.doit((i) => {
       setStore((state) => {
         state.items[i] = i;

--- a/frameworks/solid/ten-k-items-one-time/src/App.tsx
+++ b/frameworks/solid/ten-k-items-one-time/src/App.tsx
@@ -1,24 +1,25 @@
-import { createStore, onSettled, Repeat } from 'solid-js'
+import { createSignal, onSettled, Repeat } from 'solid-js'
 import { helpers } from 'common';
 
 const test = helpers.tenKitems1UpdateEach();
 
 function App() {
-  const [store, setStore] = createStore({ items: test.getData() });
+  const items = test.getData().map(item => createSignal(item));
 
   // (v1 wrapped test.run in `batch`; solid 2 batches automatically,
   // so plain doit matches the other frameworks again)
   onSettled(() => {
     test.doit((i) => {
-      setStore((state) => {
-        state.items[i] = i;
-      });
+      items[i]?.[1](i);
     });
   });
 
   return (
-    <Repeat count={store.items.length}>
-      {index => <>{test.formatItem(store.items[index])}</>}
+    <Repeat count={items.length}>
+      {index => {
+        const item = items[index]![0];
+        return <>{test.formatItem(item())}</>;
+      }}
     </Repeat>
   )
 }

--- a/frameworks/solid/ten-k-items-one-time/src/App.tsx
+++ b/frameworks/solid/ten-k-items-one-time/src/App.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createStore, For } from 'solid-js'
+import { createEffect, createStore, Repeat } from 'solid-js'
 import { helpers } from 'common';
 
 const test = helpers.tenKitems1UpdateEach();
@@ -18,7 +18,11 @@ function App() {
     });
   });
 
-  return <For each={store.items}>{i => test.formatItem(i)}</For>
+  return (
+    <Repeat count={store.items.length}>
+      {index => <>{test.formatItem(store.items[index])}</>}
+    </Repeat>
+  )
 }
 
 export default App


### PR DESCRIPTION
## Summary
- update every Solid fixture from beta.21 to the current Solid 2 beta.27, with the matching web runtime and compiler plugin
- start every Solid workload with Solid 2's canonical `onSettled` lifecycle API instead of emulating post-render setup with an empty effect computation
- preserve DOM identity explicitly: positional rendering for the fixed-size item workload, database-name keying for dbmon rows, and positional query cells
- model independently updated list items with per-item signals, matching the fine-grained shape used by the equivalent Angular fixture
- bind hot text-only outputs through `textContent`, following the current Solid Octane benchmark pass and avoiding generic child reconciliation

The Octane pass also explores shallow stores for full dbmon payload replacement. This benchmark delivers partial row patches instead, and local A/B testing showed a shallow array store was slower here, so this PR keeps the keyed map implementation.

Local beta.27 runs with 4x CPU throttling improved the 1,000-item cases from the original implementation to:
- 1,000 sequential async updates: 1099.6ms to 268.1ms (-76%)
- 50 random async updates: 69.8ms to 20.4ms (-71%)
- 1,000 synchronous updates: 19.8ms to 10.7ms (-46%)

Same-runtime A/B runs showed direct `textContent` bindings reducing affected workload medians by roughly 2-12%. Replicated isolated dbmon comparisons found beta.27 neutral-to-faster than beta.21 in script time; FPS variation between sessions was much larger than the version delta, so this PR does not make a precise dbmon percentage claim. The lifecycle change occurs before each workload's `:start` mark and does not affect the measured window.

## Test plan
- [x] `pnpm lint`
- [x] build all five Solid benchmark apps
- [x] all six Solid Playwright cases, including production builds and the dbmon dev server
- [x] targeted before/after benchmark runs with Chrome CPU throttling
- [x] same-machine beta.27 comparison against freshly built Angular fixtures
- [x] isolated beta.21/beta.27 dbmon profiling and repeated-session checks