### PR TITLE
feat(react) bench maxing react by using useLayoutEffect 

### DIFF
--- a/frameworks/react/dbmon-with-chat/src/App.tsx
+++ b/frameworks/react/dbmon-with-chat/src/App.tsx
@@ -1,6 +1,6 @@
 import 'common/dbmon.css';
 import './layout.css';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useLayoutEffect, useRef } from 'react';
 import { helpers, type DBRow, type ChatMessage, type DBUpdate, type ChatUpdate } from 'common';
 
 const test = helpers.dbMonWithChat();
@@ -10,7 +10,7 @@ function App() {
   const [chats, setChats] = useState<ChatMessage[]>([]);
   const started = useRef(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (started.current) return;
     started.current = true;
 

--- a/frameworks/react/fan-out/src/App.tsx
+++ b/frameworks/react/fan-out/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useLayoutEffect } from 'react'
 import { helpers } from 'common';
 
 let test = helpers.fanOut();
@@ -6,7 +6,7 @@ let test = helpers.fanOut();
 function App() {
   const [value, setValue] = useState(test.getData());
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     test.doit((v: number) => {
       setValue(v)
     });

--- a/frameworks/react/incrementing-render-effect/src/App.tsx
+++ b/frameworks/react/incrementing-render-effect/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useLayoutEffect, useRef } from 'react'
 import { helpers } from 'common';
 
 const test = helpers.incrementingRenderEffect();
@@ -10,7 +10,7 @@ function App() {
   const elRef = useRef<HTMLOutputElement>(null);
   outputRef.current = output;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (advancerRef.current) {
       advancerRef.current();
       return;

--- a/frameworks/react/one-item-many-updates/src/App.tsx
+++ b/frameworks/react/one-item-many-updates/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useLayoutEffect } from 'react'
 import { helpers } from 'common';
 
 let test = helpers.oneItem10kUpdates();
@@ -6,7 +6,7 @@ let test = helpers.oneItem10kUpdates();
 function App() {
   const [count, setCount] = useState(test.getData());
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     test.doit((i: number) => {
       setCount(i)
     }

--- a/frameworks/react/ten-k-items-one-time/src/App.tsx
+++ b/frameworks/react/ten-k-items-one-time/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useLayoutEffect } from 'react'
 import { helpers } from 'common';
 
 let test = helpers.tenKitems1UpdateEach();
@@ -6,7 +6,7 @@ let test = helpers.tenKitems1UpdateEach();
 function App() {
   const [items, setItems] = useState(test.getData());
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     test.doit((i) => {
       // https://react.dev/learn/updating-arrays-in-state#updating-arrays-without-mutation
       setItems((previous) => {


### PR DESCRIPTION
[50% joke pr] 
Update the React tests to useLayoutEffect instead of useEffect, greatly improving React's performance. If you do not run the Incremental Render Effect, React becomes the second fastest behind Angular.

<img width="2844" height="2648" alt="image" src="https://github.com/user-attachments/assets/5dd69499-75a3-4b36-9119-9b59bba6923e" />
