### PR TITLE
Rework variant display and add experiment support in History view

### DIFF
--- a/frameworks/vue/notes.json
+++ b/frameworks/vue/notes.json
@@ -1,0 +1,3 @@
+{
+  "variant": "Vapor"
+}

--- a/results/app/components/variant.gts
+++ b/results/app/components/variant.gts
@@ -1,0 +1,14 @@
+import type { TOC } from "@ember/component/template-only";
+
+/**
+ * A framework's variant label (e.g. "Vapor"), shown under the framework
+ * name and above its version. Renders nothing when the run recorded no
+ * variant for the framework.
+ */
+export const Variant = <template>
+  {{#if @variant}}
+    <span class="variant">{{@variant}}</span>
+  {{/if}}
+</template> satisfies TOC<{
+  variant: string | undefined;
+}>;

--- a/results/app/routes/compare.ts
+++ b/results/app/routes/compare.ts
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-import { runs } from "virtual:result-sets";
+import { experiments, runs } from "virtual:result-sets";
 
 import { warnOnVersionDivergence } from "#utils";
 
@@ -107,7 +107,9 @@ function runsFor(a: string | undefined, b: string | undefined) {
 }
 
 async function fetchResultSet(name: string): Promise<ResultSet> {
-  const response = await fetch(`/results/${name}.json`);
+  // experiments live in a separate directory from the official runs
+  const dir = experiments.includes(name) ? "experiments" : "results";
+  const response = await fetch(`/${dir}/${name}.json`);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const json = await response.json();
 

--- a/results/app/routes/compare.ts
+++ b/results/app/routes/compare.ts
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-import { results } from "virtual:result-sets";
+import { runs } from "virtual:result-sets";
 
 import { warnOnVersionDivergence } from "#utils";
 
@@ -75,20 +75,20 @@ export default class Compare extends Route<Model> {
 }
 
 /**
- * The run next to `name`, preferring `direction` -- `results` is
+ * The run next to `name`, preferring `direction` -- `runs` is
  * newest-first, so older runs are later in the list. Falls back to the
  * other side for the first and last run, and to `name` itself when it's
  * the only run there is.
  */
 function neighborOf(name: string, direction: "older" | "newer") {
-  const index = results.indexOf(name);
+  const index = runs.indexOf(name);
 
-  if (index === -1) return results[0];
+  if (index === -1) return runs[0];
 
   const [preferred, fallback] =
     direction === "older" ? [index + 1, index - 1] : [index - 1, index + 1];
 
-  return results[preferred] ?? results[fallback] ?? name;
+  return runs[preferred] ?? runs[fallback] ?? name;
 }
 
 /**
@@ -103,7 +103,7 @@ function runsFor(a: string | undefined, b: string | undefined) {
   if (a) return { a, b: neighborOf(a, "newer") };
 
   // no runs named at all -- the two most recent
-  return { a: results[1] ?? results[0], b: results[0] };
+  return { a: runs[1] ?? runs[0], b: runs[0] };
 }
 
 async function fetchResultSet(name: string): Promise<ResultSet> {

--- a/results/app/routes/index.ts
+++ b/results/app/routes/index.ts
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-import { results } from "virtual:result-sets";
+import { runs } from "virtual:result-sets";
 
 import type RouterService from "@ember/routing/router-service";
 
@@ -11,7 +11,7 @@ export default class Index extends Route {
   beforeModel() {
     this.router.transitionTo("results", {
       queryParams: {
-        q: results[0],
+        q: runs[0],
       },
     });
   }

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -1,6 +1,8 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
+import { experiments } from "virtual:result-sets";
+
 import { warnOnVersionDivergence } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
@@ -49,7 +51,9 @@ export default class Results extends Route<Model> {
     const { q } = params as unknown as Params;
 
     try {
-      const response = await fetch(`/results/${q}.json`);
+      // experiments live in a separate directory from the official runs
+      const dir = experiments.includes(q) ? "experiments" : "results";
+      const response = await fetch(`/${dir}/${q}.json`);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const json = await response.json();
 

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -65,6 +65,16 @@ h1 {
   font-size: 0.8rem;
 }
 
+/* a framework's build flavor (e.g. "Vapor"), sitting between the name and
+   the version -- a block so it lands on its own line under the name */
+.variant {
+  display: block;
+  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
 body {
   display: grid;
   gap: 0.5rem;
@@ -103,7 +113,7 @@ body {
   /* the label column is as wide as its longest benchmark name, so tables
      on the same page are different widths; lining up their right edges
      puts the same value column in the same place in each of them */
-  > table {
+  >table {
     justify-self: end;
   }
 }
@@ -114,6 +124,7 @@ body {
 }
 
 main {
+  min-width: 500px;
   display: grid;
   justify-items: center;
 }
@@ -180,6 +191,7 @@ main.error-page {
 }
 
 table {
+
   th,
   td {
     padding: 0.25rem 0.5rem;

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -113,7 +113,7 @@ body {
   /* the label column is as wide as its longest benchmark name, so tables
      on the same page are different widths; lining up their right edges
      puts the same value column in the same place in each of them */
-  >table {
+  > table {
     justify-self: end;
   }
 }
@@ -191,7 +191,6 @@ main.error-page {
 }
 
 table {
-
   th,
   td {
     padding: 0.25rem 0.5rem;

--- a/results/app/templates/compare.gts
+++ b/results/app/templates/compare.gts
@@ -4,10 +4,11 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 
 import { pageTitle } from "ember-page-title";
-import { results } from "virtual:result-sets";
+import { runs } from "virtual:result-sets";
 
 import { BenchmarkName } from "#components/benchmark-name.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import { nameOf } from "#frameworks";
 import {
@@ -21,6 +22,7 @@ import {
   round,
   throttleLabel,
   timeFor,
+  variantOf,
   versionOf,
 } from "#utils";
 
@@ -303,6 +305,16 @@ export default class Compare extends Component<{ model: Model }> {
     return lowerIsBetterBenches(this.benchmarkInfo);
   }
 
+  /**
+   * The variant either run recorded for the compared framework, preferring
+   * the candidate (B). Both runs are usually the same build, so this reads
+   * "what flavor of the framework am I looking at" rather than a per-run
+   * difference.
+   */
+  get variant() {
+    return variantOf(this.b.data, this.framework) ?? variantOf(this.a.data, this.framework);
+  }
+
   isFramework = (name: string) => this.framework === name;
 
   isRun = (which: "a" | "b", name: string) => this[which].name === name;
@@ -337,7 +349,7 @@ export default class Compare extends Component<{ model: Model }> {
       <label>
         run A
         <select name="run-a" {{on "change" (fn this.setRun "a")}}>
-          {{#each results as |name|}}
+          {{#each runs as |name|}}
             <option value={{name}} selected={{this.isRun "a" name}}>{{shortName name}}</option>
           {{/each}}
         </select>
@@ -345,7 +357,7 @@ export default class Compare extends Component<{ model: Model }> {
       <label>
         run B
         <select name="run-b" {{on "change" (fn this.setRun "b")}}>
-          {{#each results as |name|}}
+          {{#each runs as |name|}}
             <option value={{name}} selected={{this.isRun "b" name}}>{{shortName name}}</option>
           {{/each}}
         </select>
@@ -373,6 +385,7 @@ export default class Compare extends Component<{ model: Model }> {
 
     <div class="all-results">
       <FrameworkInfo @name={{this.framework}} />
+      <Variant @variant={{this.variant}} />
 
       {{#if this.higherBenches.length}}
         <h2>higher is better</h2>

--- a/results/app/templates/compare.gts
+++ b/results/app/templates/compare.gts
@@ -4,7 +4,7 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 
 import { pageTitle } from "ember-page-title";
-import { runs } from "virtual:result-sets";
+import { experiments, runs } from "virtual:result-sets";
 
 import { BenchmarkName } from "#components/benchmark-name.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
@@ -26,6 +26,7 @@ import {
   versionOf,
 } from "#utils";
 
+import type { TOC } from "@ember/component/template-only";
 import type RouterService from "@ember/routing/router-service";
 import type { Model, NamedRun } from "#routes/compare.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
@@ -44,6 +45,29 @@ function shortName(runName: string) {
 function qp(runName: string) {
   return { q: runName };
 }
+
+/**
+ * The options for one of the A/B run selectors: the official runs, plus
+ * the experiments in their own group when there are any. Either side can
+ * point at either category, so a run can be compared against an experiment.
+ */
+const RunOptions = <template>
+  <optgroup label="Runs">
+    {{#each runs as |name|}}
+      <option value={{name}} selected={{@isRun @which name}}>{{shortName name}}</option>
+    {{/each}}
+  </optgroup>
+  {{#if experiments.length}}
+    <optgroup label="Experiments">
+      {{#each experiments as |name|}}
+        <option value={{name}} selected={{@isRun @which name}}>{{shortName name}}</option>
+      {{/each}}
+    </optgroup>
+  {{/if}}
+</template> satisfies TOC<{
+  which: "a" | "b";
+  isRun: (which: "a" | "b", name: string) => boolean;
+}>;
 
 /**
  * Both runs state their throttle outright rather than leaving it to be
@@ -349,17 +373,13 @@ export default class Compare extends Component<{ model: Model }> {
       <label>
         run A
         <select name="run-a" {{on "change" (fn this.setRun "a")}}>
-          {{#each runs as |name|}}
-            <option value={{name}} selected={{this.isRun "a" name}}>{{shortName name}}</option>
-          {{/each}}
+          <RunOptions @which="a" @isRun={{this.isRun}} />
         </select>
       </label>
       <label>
         run B
         <select name="run-b" {{on "change" (fn this.setRun "b")}}>
-          {{#each runs as |name|}}
-            <option value={{name}} selected={{this.isRun "b" name}}>{{shortName name}}</option>
-          {{/each}}
+          <RunOptions @which="b" @isRun={{this.isRun}} />
         </select>
       </label>
       <label>

--- a/results/app/templates/history.gts
+++ b/results/app/templates/history.gts
@@ -1,7 +1,7 @@
 import { LinkTo } from "@ember/routing";
 
 import { pageTitle } from "ember-page-title";
-import { results } from "virtual:result-sets";
+import { experiments, runs } from "virtual:result-sets";
 
 function qp(resultName: string) {
   return { q: resultName };
@@ -12,16 +12,37 @@ function qp(resultName: string) {
 
   <main>
     <h1>Choose benchmark run</h1>
-    <nav>
-      <ul>
-        {{#each results as |resultName|}}
-          <li>
-            <LinkTo @route="results" @query={{qp resultName}}>
-              {{resultName}}
-            </LinkTo>
-          </li>
-        {{/each}}
-      </ul>
-    </nav>
+
+    <section>
+      <h2>Runs</h2>
+      <nav>
+        <ul>
+          {{#each runs as |resultName|}}
+            <li>
+              <LinkTo @route="results" @query={{qp resultName}}>
+                {{resultName}}
+              </LinkTo>
+            </li>
+          {{/each}}
+        </ul>
+      </nav>
+    </section>
+
+    {{#if experiments.length}}
+      <section>
+        <h2>Experiments</h2>
+        <nav>
+          <ul>
+            {{#each experiments as |resultName|}}
+              <li>
+                <LinkTo @route="results" @query={{qp resultName}}>
+                  {{resultName}}
+                </LinkTo>
+              </li>
+            {{/each}}
+          </ul>
+        </nav>
+      </section>
+    {{/if}}
   </main>
 </template>

--- a/results/app/templates/results/animated.gts
+++ b/results/app/templates/results/animated.gts
@@ -4,8 +4,9 @@ import { assert } from "@ember/debug";
 import { service } from "@ember/service";
 
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
-import { dataOf, percentileFrom, round } from "#utils";
+import { dataOf, percentileFrom, round, variantOf } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
 import type { Model } from "#routes/results.ts";
@@ -117,6 +118,7 @@ export class Visualize extends Component<{
             <tr>
               <td>
                 <FrameworkInfo @name={{fw.name}} />
+                <Variant @variant={{variantOf @file fw.name}} />
               </td>
               <td class="time">{{round fw.speed}}
                 {{fw.units}}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -7,6 +7,7 @@ import { interpolate } from "culori";
 
 import { BenchmarkName } from "#components/benchmark-name.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
   higherIsBetterBenches,
@@ -17,6 +18,7 @@ import {
   PERCENTILES,
   round,
   timeFor,
+  variantOf,
   versionOf,
 } from "#utils";
 
@@ -277,6 +279,7 @@ class Table extends Component<{
           {{#each this.frameworkNames as |framework|}}
             <th class="fw-header">
               <FrameworkInfo @name={{framework}} />
+              <Variant @variant={{variantOf @file framework}} />
               <span class="small">
                 <Version
                   @version={{versionOf @file framework}}

--- a/results/app/types.ts
+++ b/results/app/types.ts
@@ -40,6 +40,18 @@ export interface VersionOverride {
   url: string;
 }
 
+/**
+ * Small labels a run records about a framework, collected by the runner
+ * from `frameworks/<framework>/notes.json`.
+ */
+export interface FrameworkNotes {
+  /**
+   * The flavor of the framework the run used -- e.g. "Vapor" for a Vue
+   * Vapor build. Shown under the framework's name, above its version.
+   */
+  variant?: string;
+}
+
 export interface BenchmarkInfo {
   name: string;
   app: string;
@@ -91,6 +103,12 @@ export interface ResultSet {
    * framework name, e.g. `{ ember: { number: 21513, url: "https://..." } }`.
    */
   versionOverrides?: Record<string, VersionOverride>;
+  /**
+   * Optional per-framework notes, keyed by framework name. Collected by the
+   * runner from `frameworks/<framework>/notes.json`, e.g.
+   * `{ vue: { variant: "Vapor" } }`.
+   */
+  notes?: Record<string, FrameworkNotes>;
   environment: {
     machine: {
       os: {

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -49,6 +49,14 @@ export function overrideOf(file: ResultSet, framework: string) {
 }
 
 /**
+ * The variant a run recorded for a framework, if any -- e.g. "Vapor" for a
+ * Vue Vapor build. Shown under the framework's name, above its version.
+ */
+export function variantOf(file: ResultSet, framework: string) {
+  return file.notes?.[framework]?.variant;
+}
+
+/**
  * How one framework did at one benchmark, or undefined when that run
  * doesn't have the pair.
  */

--- a/results/public/experiments/ember-2026-07-29T02:20:30.864Z.json
+++ b/results/public/experiments/ember-2026-07-29T02:20:30.864Z.json
@@ -1,17 +1,25 @@
 {
-  "date": "2026-07-23T00:31:24.817Z",
-  "sha": "e7d3d9023fe35ce4b6b6c3770b2ccc8428db4915",
-  "versionOverrides": {
-    "ember": {
-      "number": 21514,
-      "url": "https://github.com/emberjs/ember.js/pull/21514"
-    }
-  },
+  "date": "2026-07-29T02:20:30.864Z",
+  "sha": "a6986262707fdc97d09fd60fb2355cadeb5ea37e",
   "args": {
     "SKIP_BUILD": false,
     "CPU_THROTTLE": 4,
     "HEADLESS": false,
-    "COUNT": 10
+    "COUNT": 10,
+    "FRAMEWORK": "all",
+    "BENCH_NAME": "all",
+    "TIMEOUT": 60000
+  },
+  "versionOverrides": {
+    "ember": {
+      "number": "21520",
+      "url": "https://github.com/emberjs/ember.js/pull/21520"
+    }
+  },
+  "notes": {
+    "vue": {
+      "variant": "Vapor"
+    }
   },
   "environment": {
     "machine": {
@@ -40,57 +48,61 @@
           [
             {
               "name": "mark_feature_usage",
-              "at": 42.799999952316284,
+              "at": 37.39999985694885,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 59.200000047683716,
+              "at": 53.59999990463257,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 64.09999990463257,
+              "at": 57.19999980926514,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 109.5
+              "at": 96.29999995231628
             },
             {
               "name": "fps",
-              "at": 5196,
-              "detail": 112.7
+              "at": 5197.299999952316,
+              "detail": 116.8
             },
             {
               "name": "fps",
-              "at": 10194.599999904633,
-              "detail": 119.1
+              "at": 10198.099999904633,
+              "detail": 119.19786846164632
             },
             {
               "name": "fps",
-              "at": 15187.700000047684,
-              "detail": 119.7
+              "at": 15198.699999809265,
+              "detail": 119.60239204784098
             },
             {
               "name": "fps",
-              "at": 20193.299999952316,
-              "detail": 118.5
+              "at": 20197.299999952316,
+  "detail": 118
             },
             {
               "name": "fps",
-              "at": 25192.299999952316,
-              "detail": 118.9
+              "at": 25204,
+              "detail": 119.8
             },
             {
               "name": ":done",
-              "at": 25195.700000047684
+              "at": 25205.099999904633,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -105,300 +117,161 @@
           [
             {
               "name": "mark_feature_usage",
-              "at": 39.200000047683716,
+              "at": 40.39999985694885,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.10000014305115,
+              "at": 57.299999952316284,
               "detail": {
                 "feature": "NgAfterRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 58.10000014305115,
+              "at": 58.19999980926514,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 74.29999995231628
+              "at": 74.59999990463257
             },
             {
               "name": ":done",
-              "at": 1529.5
+              "at": 1521.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 39,
+              "at": 35.200000047683716,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 55.799999952316284,
+              "at": 49.90000009536743,
               "detail": {
                 "feature": "NgAfterRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.90000009536743,
+              "at": 50.90000009536743,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 74.90000009536743
+              "at": 68.10000014305115
             },
             {
               "name": ":done",
-              "at": 1372.9000000953674
+              "at": 1342.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.90000009536743,
+              "at": 33.200000047683716,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 54.10000014305115,
+              "at": 48.5,
               "detail": {
                 "feature": "NgAfterRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 55.80000019073486,
+              "at": 49.09999990463257,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 73.20000004768372
+              "at": 78.09999990463257
             },
             {
               "name": ":done",
-              "at": 1368.5
+              "at": 1345.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 34.80000019073486,
+              "at": 33.60000014305115,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 51,
+              "at": 47.80000019073486,
               "detail": {
                 "feature": "NgAfterRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 51.90000009536743,
+              "at": 48.90000009536743,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 73.40000009536743
+              "at": 84.20000004768372
             },
             {
               "name": ":done",
-              "at": 1392.2000000476837
+              "at": 1387.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 32.09999990463257,
+              "at": 34.700000047683716,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 47.19999980926514,
+              "at": 49,
               "detail": {
                 "feature": "NgAfterRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 48,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 69.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1371.8999998569489
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.69999980926514,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.89999985694885,
-              "detail": {
-                "feature": "NgAfterRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.39999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 70
-            },
-            {
-              "name": ":done",
-              "at": 1367.5999999046326
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 38,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.89999985694885,
-              "detail": {
-                "feature": "NgAfterRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 73.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 1374.8999998569489
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.09999990463257,
-              "detail": {
-                "feature": "NgAfterRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 75.5
-            },
-            {
-              "name": ":done",
-              "at": 1355.7999999523163
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.59999990463257,
-              "detail": {
-                "feature": "NgAfterRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 1365.7999999523163
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.40000009536743,
-              "detail": {
-                "feature": "NgAfterRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.299999952316284,
+              "at": 50,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
@@ -409,7 +282,186 @@
             },
             {
               "name": ":done",
-              "at": 1403.7000000476837
+              "at": 1337.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.10000014305115,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.700000047683716,
+              "detail": {
+                "feature": "NgAfterRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 1409.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.39999985694885,
+              "detail": {
+                "feature": "NgAfterRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 67.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 1350.1999998092651,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.90000009536743,
+              "detail": {
+                "feature": "NgAfterRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69
+            },
+            {
+              "name": ":done",
+              "at": 1371.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.5,
+              "detail": {
+                "feature": "NgAfterRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1375.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.39999985694885,
+              "detail": {
+                "feature": "NgAfterRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 66.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1361.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -423,470 +475,6 @@
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.39999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.39999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 70.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 80.20000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 65.5
-            },
-            {
-              "name": ":done",
-              "at": 74.09999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.19999980926514,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 74.5
-            },
-            {
-              "name": ":done",
-              "at": 82.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.10000014305115,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.30000019073486,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 73.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 81.20000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67
-            },
-            {
-              "name": ":done",
-              "at": 73.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.60000014305115,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67
-            },
-            {
-              "name": ":done",
-              "at": 74.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 46.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 66.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 72.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 69.5
-            },
-            {
-              "name": ":done",
-              "at": 78.69999980926514
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.80000019073486,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.30000019073486,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 66.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 75.20000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 40.39999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.39999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 75.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 82.09999990463257
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 1k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=1000&percentRandomAwait=0",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.40000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 68.5
-            },
-            {
-              "name": ":done",
-              "at": 74.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.80000019073486,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 68.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 74.60000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 72.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 78.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 74.30000019073486
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 68.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 74
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.699999809265137,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 45.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 66.5
-            },
-            {
-              "name": ":done",
-              "at": 72.39999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 30.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 44.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 64.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 72
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 69.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 76
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 74.60000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
               "at": 34.09999990463257,
               "detail": {
                 "feature": "NgStandalone"
@@ -894,128 +482,56 @@
             },
             {
               "name": "mark_feature_usage",
-              "at": 48.39999985694885,
+              "at": 49.39999985694885,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 69.20000004768372
+              "at": 67.89999985694885
             },
             {
               "name": ":done",
-              "at": 77.70000004768372
+              "at": 74.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates (async)": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=100",
-        "version": "22.0.8",
-        "times": [
+          ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 30.59999990463257,
+              "at": 31.300000190734863,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 44.19999980926514,
+              "at": 43.80000019073486,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 62.799999952316284
+              "at": 56.5
             },
             {
               "name": ":done",
-              "at": 106.39999985694885
+              "at": 65.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 35.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 114.09999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 68.5
-            },
-            {
-              "name": ":done",
-              "at": 111.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 41.10000014305115,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 72.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 114.30000019073486
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.899999856948853,
+              "at": 32.09999990463257,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -1029,313 +545,105 @@
             },
             {
               "name": ":start",
-              "at": 67.89999985694885
+              "at": 65.20000004768372
             },
             {
               "name": ":done",
-              "at": 106.59999990463257
+              "at": 72.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 32.60000014305115,
+              "at": 37.80000019073486,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 48.200000047683716,
+              "at": 53,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 69.90000009536743
+              "at": 71.10000014305115
             },
             {
               "name": ":done",
-              "at": 111.40000009536743
+              "at": 77.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.5,
+              "at": 34.80000019073486,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 51.09999990463257,
+              "at": 49.80000019073486,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 64.29999995231628
+              "at": 65.10000014305115
             },
             {
               "name": ":done",
-              "at": 102.79999995231628
+              "at": 71.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 37.40000009536743,
+              "at": 33.299999952316284,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 53.30000019073486,
+              "at": 47.40000009536743,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 69.5
+              "at": 65.90000009536743
             },
             {
               "name": ":done",
-              "at": 109.40000009536743
+              "at": 73.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 71.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 109.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 71.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 114.70000004768372
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=0",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.60000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 73.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 85.10000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 89
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67
-            },
-            {
-              "name": ":done",
-              "at": 78.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 45.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 77.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 95.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.60000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 69.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 81.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 69.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 80.19999980926514
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.19999980926514,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.69999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 67.5
-            },
-            {
-              "name": ":done",
-              "at": 77.09999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.40000009536743,
+              "at": 33.90000009536743,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -1349,59 +657,963 @@
             },
             {
               "name": ":start",
-              "at": 71
+              "at": 65.40000009536743
             },
             {
               "name": ":done",
-              "at": 81.79999995231628
+              "at": 71.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.90000009536743,
+              "at": 39,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 51.799999952316284,
+              "at": 53.799999952316284,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 71.29999995231628
+              "at": 69.79999995231628
             },
             {
               "name": ":done",
-              "at": 82.40000009536743
+              "at": 77,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.10000014305115,
+              "at": 36.59999990463257,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56,
+              "at": 50.89999985694885,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": ":start",
-              "at": 71.79999995231628
+              "at": 68.5
             },
             {
               "name": ":done",
-              "at": 82.70000004768372
+              "at": 74.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.59999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 66.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 76.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 1k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=1000&percentRandomAwait=0",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.19999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69.5
+            },
+            {
+              "name": ":done",
+              "at": 74.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.60000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 68.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 73.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.19999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 72.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 77.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.89999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 68.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 73.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 68.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 73.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 39.60000014305115,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.30000019073486,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 70.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 77,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 39.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.59999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 66.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 75.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 30.600000143051147,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 45.60000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 65
+            },
+            {
+              "name": ":done",
+              "at": 71.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.10000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 66.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 72.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.40000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 64.5
+            },
+            {
+              "name": ":done",
+              "at": 72.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates (async)": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=100",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.299999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 67.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 106.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.80000019073486,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 71.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 111.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 70.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 107.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 106.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 65.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 104.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 68.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 107.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.90000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 64.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 102.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.30000019073486,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 63.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 104.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 68.5
+            },
+            {
+              "name": ":done",
+              "at": 112.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.69999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 72.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 111,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=0",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 67.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 78.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.299999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69.5
+            },
+            {
+              "name": ":done",
+              "at": 80,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 70.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 80.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 63.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 75.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 69
+            },
+            {
+              "name": ":done",
+              "at": 79.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 30.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 44.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 64.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 76,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 65.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 74.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 67.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 79.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 63.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 75.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 63.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 75.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -1415,193 +1627,42 @@
           [
             {
               "name": "mark_feature_usage",
-              "at": 35.5,
+              "at": 32.299999952316284,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 53.700000047683716,
+              "at": 48.700000047683716,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 55.90000009536743,
+              "at": 51.59999990463257,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 117.79999995231628
+              "at": 109.79999995231628
             },
             {
               "name": ":done",
-              "at": 145.40000009536743
+              "at": 124,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.89999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.39999985694885,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 144.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.30000019073486,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 61.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 119.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 146.90000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.69999980926514,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114.5
-            },
-            {
-              "name": ":done",
-              "at": 142.89999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 106.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 134.20000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47.80000019073486,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 136.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.5,
+              "at": 32.59999990463257,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -1615,411 +1676,70 @@
             },
             {
               "name": "mark_feature_usage",
-              "at": 53.90000009536743,
+              "at": 53.09999990463257,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 135.60000014305115
+              "at": 112.59999990463257
             },
             {
               "name": ":done",
-              "at": 162.90000009536743
+              "at": 129.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.30000019073486,
+              "at": 36.700000047683716,
               "detail": {
                 "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 116.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 143.80000019073486
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.09999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 118.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 145.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.30000019073486,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 106.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 134.20000004768372
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items, 1 update each (sequentially)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=1000&percentRandomAwait=0",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.799999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 109.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 132.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.39999985694885,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 136.39999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 116.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 141.60000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 107.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 129.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 139.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
               "at": 53.299999952316284,
               "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 107.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 177.10000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.69999980926514,
-              "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.19999980926514,
+              "at": 54.90000009536743,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 108.29999995231628
+              "at": 107.70000004768372
             },
             {
               "name": ":done",
-              "at": 134.39999985694885
+              "at": 122.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 37,
+              "at": 32.19999980926514,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 53.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 109.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 135.29999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.30000019073486,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111
-            },
-            {
-              "name": ":done",
-              "at": 133.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.09999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.299999952316284,
+              "at": 48.799999952316284,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
@@ -2033,273 +1753,309 @@
             },
             {
               "name": ":start",
-              "at": 104.5
+              "at": 106.19999980926514
             },
             {
               "name": ":done",
-              "at": 128.5
+              "at": 122.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 104.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 119.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.19999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.89999985694885,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.5
+            },
+            {
+              "name": ":done",
+              "at": 129.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.89999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 121.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.600000143051147,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.60000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.10000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 123.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.40000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.90000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 112.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 127.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 42.09999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 60.69999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 62.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 118.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 136,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
         "whatsBetter": "smaller"
       },
-      "1k items 1 update on 5% (random, async)": {
+      "1k items, 1 update each (sequentially)": {
         "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=50&random=true&percentRandomAwait=100",
+        "query": "&items=1000&updates=1000&percentRandomAwait=0",
         "version": "22.0.8",
         "times": [
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.700000047683716,
+              "at": 34.40000009536743,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.40000009536743,
+              "at": 51.40000009536743,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 58.40000009536743,
+              "at": 53,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 115.29999995231628
+              "at": 107.80000019073486
             },
             {
               "name": ":done",
-              "at": 145
+              "at": 122,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.80000019073486,
+              "at": 35.799999952316284,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 54.60000014305115,
+              "at": 52.89999985694885,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.60000014305115,
+              "at": 54.39999985694885,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 110.30000019073486
+              "at": 130.59999990463257
             },
             {
               "name": ":done",
-              "at": 136.40000009536743
+              "at": 145.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.90000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 135.90000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.39999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.69999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.39999985694885,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 146
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 40.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 61.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 121.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 143.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 138.09999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.299999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 108.5
-            },
-            {
-              "name": ":done",
-              "at": 131.60000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.09999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 101.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 124.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.700000047683716,
+              "at": 32.10000014305115,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -2313,24 +2069,997 @@
             },
             {
               "name": "mark_feature_usage",
-              "at": 51.200000047683716,
+              "at": 50.799999952316284,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 107.5
+              "at": 104.40000009536743
             },
             {
               "name": ":done",
-              "at": 129.09999990463257
+              "at": 116.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 33.200000047683716,
+              "at": 35.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 121.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 60,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 116.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 129,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.90000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 121.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.10000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.5
+            },
+            {
+              "name": ":done",
+              "at": 118.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.09999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.299999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109
+            },
+            {
+              "name": ":done",
+              "at": 121.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 59.39999985694885,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 116.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 129.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108
+            },
+            {
+              "name": ":done",
+              "at": 121.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 5% (random, async)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=50&random=true&percentRandomAwait=100",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 104.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 113.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.80000019073486,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.40000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.80000019073486,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 104.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 113.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.100000143051147,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.10000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.60000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 103.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 111.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 118.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.19999980926514,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.5
+            },
+            {
+              "name": ":done",
+              "at": 123.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 110.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 119.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 58.90000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 121.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 105.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 114,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.10000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 105
+            },
+            {
+              "name": ":done",
+              "at": 113.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 126.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 134.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 5% (random)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=50&random=true&percentRandomAwait=0",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.09999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 115.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.40000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.60000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109
+            },
+            {
+              "name": ":done",
+              "at": 117.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.19999980926514,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.39999985694885,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 103.5
+            },
+            {
+              "name": ":done",
+              "at": 112.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.19999980926514,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 59.69999980926514,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 117.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 128.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 39.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 58.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 60.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 121.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 117.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 107.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 117.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.30000019073486,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.60000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.10000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 107.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 116.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 115.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.69999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 116.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 25% (random, async)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=250&random=true&percentRandomAwait=100",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.299999952316284,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -2351,125 +3080,133 @@
             },
             {
               "name": ":start",
-              "at": 106.60000014305115
+              "at": 106.20000004768372
             },
             {
               "name": ":done",
-              "at": 135.20000004768372
+              "at": 118.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 5% (random)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=50&random=true&percentRandomAwait=0",
-        "version": "22.0.8",
-        "times": [
+          ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 33.700000047683716,
+              "at": 33.19999980926514,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 52,
+              "at": 50.09999990463257,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 54.799999952316284,
+              "at": 52.5,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 110.5
+              "at": 111.29999995231628
             },
             {
               "name": ":done",
-              "at": 138.79999995231628
+              "at": 122.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 38.700000047683716,
+              "at": 37,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 57.10000014305115,
+              "at": 53.59999990463257,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 59.200000047683716,
+              "at": 55.700000047683716,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 111.5
+              "at": 104.59999990463257
             },
             {
               "name": ":done",
-              "at": 134.70000004768372
+              "at": 116,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 35.30000019073486,
+              "at": 37.09999990463257,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 52.700000047683716,
+              "at": 53.09999990463257,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 55,
+              "at": 54.89999985694885,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 111.60000014305115
+              "at": 108.20000004768372
             },
             {
               "name": ":done",
-              "at": 142.20000004768372
+              "at": 120.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 37.10000014305115,
+              "at": 36,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 54.10000014305115,
+              "at": 54.700000047683716,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
@@ -2483,1669 +3220,21 @@
             },
             {
               "name": ":start",
-              "at": 110.29999995231628
+              "at": 109.70000004768372
             },
             {
               "name": ":done",
-              "at": 133.70000004768372
+              "at": 121.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 36.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 142.90000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.09999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.09999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.5
-            },
-            {
-              "name": ":done",
-              "at": 136
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 40.89999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 133.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 156.89999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.40000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 141.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 101.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 123.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 110.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 141.09999990463257
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 25% (random, async)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=250&random=true&percentRandomAwait=100",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 61,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 139.10000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.200000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 106.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 128.90000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 112.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 138.10000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.40000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.10000014305115,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 146.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 32.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 108.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 138.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.30000019073486,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 106.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 131
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.39999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.09999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 104.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 136.39999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.60000014305115,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.60000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 138.60000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 139.59999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.200000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 112.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 140
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 25% (random)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 38.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.60000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 117.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 147.10000014305115
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 134.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 157.40000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.30000019073486,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 110.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 136.80000019073486
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.200000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.10000014305115,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 112.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 142
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.60000014305115,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 112
-            },
-            {
-              "name": ":done",
-              "at": 137
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.39999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.09999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 139.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.90000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.299999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 107.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 136.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.700000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.30000019073486,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 140
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.799999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 107.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 136.89999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.10000014305115,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.90000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 118.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 146.40000009536743
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (bursts of 100)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=100",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 41.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.39999985694885,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 138.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 1387.8999998569489
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 117
-            },
-            {
-              "name": ":done",
-              "at": 1429.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 1325.0999999046326
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 108.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 1319.7000000476837
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.299999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 120.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1357.9000000953674
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.89999985694885,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 57.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114
-            },
-            {
-              "name": ":done",
-              "at": 1327.3999998569489
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.5,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.69999980926514,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 1304
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.89999985694885,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 59.19999980926514,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 116
-            },
-            {
-              "name": ":done",
-              "at": 1300
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 39.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.40000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 134.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 1375.1000001430511
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.799999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.19999980926514,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 137
-            },
-            {
-              "name": ":done",
-              "at": 1375
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=1000",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.40000009536743,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 134.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 293.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.799999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 115
-            },
-            {
-              "name": ":done",
-              "at": 265.89999985694885
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.90000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 118.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 279.2000000476837
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 119
-            },
-            {
-              "name": ":done",
-              "at": 277.2000000476837
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49.40000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 274
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 38.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.40000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.59999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 113.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 263.90000009536743
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 38.09999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.799999952316284,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 58.69999980926514,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 116.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 284.5
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 50.60000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 54.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111
-            },
-            {
-              "name": ":done",
-              "at": 270.2999999523163
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.200000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47.90000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.10000014305115,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 116.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 269
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 36.80000019073486,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 52.10000014305115,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 56.200000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 133
-            },
-            {
-              "name": ":done",
-              "at": 283.7000000476837
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (single burst)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=10000",
-        "version": "22.0.8",
-        "times": [
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 33.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 48.40000009536743,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.299999952316284,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 118.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 151.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 37.59999990463257,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 51.200000047683716,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 55.700000047683716,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 120
-            },
-            {
-              "name": ":done",
-              "at": 155.70000004768372
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 31.899999856948853,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 46.5,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 111.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 123.09999990463257
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 30.700000047683716,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 44.09999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 47.09999990463257,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 105.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 117
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 29.399999856948853,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 43.59999990463257,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 46.5,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 114.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 146.79999995231628
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 34.299999952316284,
-              "detail": {
-                "feature": "NgStandalone"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 49,
-              "detail": {
-                "feature": "NgAfterNextRender"
-              }
-            },
-            {
-              "name": "mark_feature_usage",
-              "at": 53.40000009536743,
-              "detail": {
-                "feature": "NgControlFlow"
-              }
-            },
-            {
-              "name": ":start",
-              "at": 119
-            },
-            {
-              "name": ":done",
-              "at": 152
-            }
-          ],
-          [
-            {
-              "name": "mark_feature_usage",
-              "at": 35.700000047683716,
+              "at": 32.799999952316284,
               "detail": {
                 "feature": "NgStandalone"
               }
@@ -4159,6 +3248,1220 @@
             },
             {
               "name": "mark_feature_usage",
+              "at": 51.90000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 105
+            },
+            {
+              "name": ":done",
+              "at": 116.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.200000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 118.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.80000019073486,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 110.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 123.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.60000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 122.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.200000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 125.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 25% (random)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.80000019073486,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.40000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 118.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 105.5
+            },
+            {
+              "name": ":done",
+              "at": 116.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.10000014305115,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 107.5
+            },
+            {
+              "name": ":done",
+              "at": 118,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 107.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 118.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.799999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 58.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 118.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 127.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 39.10000014305115,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.10000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 110.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 121.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.59999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.09999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115
+            },
+            {
+              "name": ":done",
+              "at": 125.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 40.299999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 58,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 60.200000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 126.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.09999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 106.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 116.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 35.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.59999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 119.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (bursts of 100)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=100",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.700000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1227.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 45.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 1203.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.09999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 108.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 1138.9000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 55.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 122.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 1324.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.30000019073486,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.60000014305115,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 117
+            },
+            {
+              "name": ":done",
+              "at": 1210.1000001430511,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 31.799999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.200000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 112.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1213.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.200000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 109.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 1234.6000001430511,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 119.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1254.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 116.5
+            },
+            {
+              "name": ":done",
+              "at": 1159.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.19999980926514,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 1353.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=1000",
+        "version": "22.0.8",
+        "times": [
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.90000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 126.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 278.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.09999990463257,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 113.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 253.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 34.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 116.5
+            },
+            {
+              "name": ":done",
+              "at": 280.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.39999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.5
+            },
+            {
+              "name": ":done",
+              "at": 273.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 51.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 118.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 277.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 37.90000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 54.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 57.40000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 114.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 275.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.5,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 45.89999985694885,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.700000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 110
+            },
+            {
+              "name": ":done",
+              "at": 273.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 40.90000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 59.200000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 63.40000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 122.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 280,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 38.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.59999990463257,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 112
+            },
+            {
+              "name": ":done",
+              "at": 265.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.200000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
               "at": 52.200000047683716,
               "detail": {
                 "feature": "NgControlFlow"
@@ -4166,24 +4469,36 @@
             },
             {
               "name": ":start",
-              "at": 109.29999995231628
+              "at": 118.40000009536743
             },
             {
               "name": ":done",
-              "at": 141
+              "at": 276.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
-          ],
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (single burst)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=10000",
+        "version": "22.0.8",
+        "times": [
           [
             {
               "name": "mark_feature_usage",
-              "at": 33.799999952316284,
+              "at": 35.80000019073486,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 49.700000047683716,
+              "at": 49.30000019073486,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
@@ -4197,73 +4512,330 @@
             },
             {
               "name": ":start",
-              "at": 118.20000004768372
+              "at": 116.40000009536743
             },
             {
               "name": ":done",
-              "at": 151.79999995231628
+              "at": 129.20000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 34.40000009536743,
+              "at": 40.200000047683716,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 50.59999990463257,
+              "at": 55.40000009536743,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 54.90000009536743,
+              "at": 57.90000009536743,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 115.90000009536743
+              "at": 140.90000009536743
             },
             {
               "name": ":done",
-              "at": 126.20000004768372
+              "at": 176.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": "mark_feature_usage",
-              "at": 40.799999952316284,
+              "at": 32.80000019073486,
               "detail": {
                 "feature": "NgStandalone"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 56.5,
+              "at": 49.60000014305115,
               "detail": {
                 "feature": "NgAfterNextRender"
               }
             },
             {
               "name": "mark_feature_usage",
-              "at": 59.59999990463257,
+              "at": 53.5,
               "detail": {
                 "feature": "NgControlFlow"
               }
             },
             {
               "name": ":start",
-              "at": 117.59999990463257
+              "at": 117.80000019073486
             },
             {
               "name": ":done",
-              "at": 148.39999985694885
+              "at": 148.40000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 56.59999990463257,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 71.79999995231628,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 75.5,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 143.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 176.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 32.89999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.5
+            },
+            {
+              "name": ":done",
+              "at": 145.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 41.39999985694885,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 56.299999952316284,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 59.69999980926514,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 120
+            },
+            {
+              "name": ":done",
+              "at": 130.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 30.700000047683716,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 45.10000014305115,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 47.700000047683716,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 105.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 136.40000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 46.5,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 48.89999985694885,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 116.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 144.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 33.40000009536743,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 49.700000047683716,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 52.799999952316284,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 119.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 151.29999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": "mark_feature_usage",
+              "at": 36.299999952316284,
+              "detail": {
+                "feature": "NgStandalone"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 50.90000009536743,
+              "detail": {
+                "feature": "NgAfterNextRender"
+              }
+            },
+            {
+              "name": "mark_feature_usage",
+              "at": 53.40000009536743,
+              "detail": {
+                "feature": "NgControlFlow"
+              }
+            },
+            {
+              "name": ":start",
+              "at": 115.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 145.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -4279,36 +4851,40 @@
           [
             {
               "name": ":start",
-              "at": 132.40000009536743
+              "at": 127.5
             },
             {
               "name": "fps",
-              "at": 5260.100000143051,
-              "detail": 92.7
+              "at": 5252,
+              "detail": 106.8
             },
             {
               "name": "fps",
-              "at": 10263.800000190735,
-              "detail": 101.7
+              "at": 10258.5,
+              "detail": 103.1712642987359
             },
             {
               "name": "fps",
-              "at": 15264.400000095367,
-              "detail": 106.1
+              "at": 15253.399999856949,
+              "detail": 104.97425726706335
             },
             {
               "name": "fps",
-              "at": 20277.60000014305,
-              "detail": 109.1
+              "at": 20252.299999952316,
+              "detail": 113.58855700462766
             },
             {
               "name": "fps",
-              "at": 25270.10000014305,
-              "detail": 99.3
+              "at": 25264.599999904633,
+              "detail": 111.2
             },
             {
               "name": ":done",
-              "at": 25272.700000047684
+              "at": 25266.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -4318,144 +4894,20 @@
       "Incrementing Render Effect": {
         "app": "incrementing-render-effect",
         "query": "&updates=100000",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 118
+              "at": 116.70000004768372
             },
             {
               "name": ":done",
-              "at": 1641.8000001907349
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 110.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 1484.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 114.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 1519.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 117.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 1529.1000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 114.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 1484.5999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 120
-            },
-            {
-              "name": ":done",
-              "at": 1506.5999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 139.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1683.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 125.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1516.0999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 116.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1511.8999998569489
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 118.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 1494.3000001907349
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 1k updates (async)": {
-        "app": "one-item-many-updates",
-        "query": "&updates=1000&percentRandomAwait=100",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 119.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 150.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 127
-            },
-            {
-              "name": ":done",
-              "at": 162.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 122.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 157.20000004768372
+              "at": 1643,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -4465,311 +4917,109 @@
             },
             {
               "name": ":done",
-              "at": 146.79999995231628
+              "at": 1469.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 115.29999995231628
+              "at": 109.59999990463257
             },
             {
               "name": ":done",
-              "at": 156.20000004768372
+              "at": 1496.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 123.59999990463257
+              "at": 115.30000019073486
             },
             {
               "name": ":done",
-              "at": 158.70000004768372
+              "at": 1481.4000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.20000004768372
+              "at": 114.80000019073486
             },
             {
               "name": ":done",
-              "at": 166.5
+              "at": 1459.9000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.19999980926514
+              "at": 106.79999995231628
             },
             {
               "name": ":done",
-              "at": 164.59999990463257
+              "at": 1463.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 124.20000004768372
+              "at": 103.79999995231628
             },
             {
               "name": ":done",
-              "at": 171.5
+              "at": 1421.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.89999985694885
+              "at": 113.90000009536743
             },
             {
               "name": ":done",
-              "at": 162.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 1k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=1000&percentRandomAwait=0",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 124.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 132.09999990463257
+              "at": 1492.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 115.90000009536743
+              "at": 111.60000014305115
             },
             {
               "name": ":done",
-              "at": 124.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 141.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 149.69999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 118.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 125.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 124.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 132.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 119.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 127.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 119.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 129
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 130
-            },
-            {
-              "name": ":done",
-              "at": 136.30000019073486
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 120.5
-            },
-            {
-              "name": ":done",
-              "at": 130.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 112.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 122.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates (async)": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=100",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 114.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 788.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 117
-            },
-            {
-              "name": ":done",
-              "at": 790.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 122.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 776.9000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 113.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 763.8999998569489
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 114.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 789.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 117.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 790.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 117.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 798.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 118.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 777.0999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 117.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 789.1000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 119.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 798
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=0",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 127.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 162.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 122.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 150.79999995231628
+              "at": 1498.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -4779,77 +5029,603 @@
             },
             {
               "name": ":done",
-              "at": 134.79999995231628
+              "at": 1476.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 1k updates (async)": {
+        "app": "one-item-many-updates",
+        "query": "&updates=1000&percentRandomAwait=100",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 114.5
+            },
+            {
+              "name": ":done",
+              "at": 121.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.89999985694885
+              "at": 120
             },
             {
               "name": ":done",
-              "at": 145.20000004768372
+              "at": 126.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.5
+              "at": 116.70000004768372
             },
             {
               "name": ":done",
-              "at": 142.20000004768372
+              "at": 123.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 119.39999985694885
+              "at": 115
             },
             {
               "name": ":done",
-              "at": 143.79999995231628
+              "at": 121.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 119
+              "at": 118.5
             },
             {
               "name": ":done",
-              "at": 151.10000014305115
+              "at": 125,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.30000019073486
+              "at": 111.60000014305115
             },
             {
               "name": ":done",
-              "at": 151.60000014305115
+              "at": 118.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.20000004768372
+              "at": 114.20000004768372
             },
             {
               "name": ":done",
-              "at": 143.29999995231628
+              "at": 120.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 116.29999995231628
+              "at": 115.09999990463257
             },
             {
               "name": ":done",
-              "at": 141.09999990463257
+              "at": 122,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 111.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 120.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 114.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 121.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 1k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=1000&percentRandomAwait=0",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 112.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 118.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 120.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 127.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 130.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 136,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 118.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 124.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 111.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 117,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 120.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 127,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 117.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 124,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 120.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 126.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 117.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 122.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 119.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 125.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates (async)": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=100",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 113.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 160.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 114
+            },
+            {
+              "name": ":done",
+              "at": 165.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 113
+            },
+            {
+              "name": ":done",
+              "at": 164.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 117.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 166.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 111.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 156.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 110.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 158.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 109.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 157.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 117.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 166.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 111.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 159.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 110.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 160.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=0",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 108
+            },
+            {
+              "name": ":done",
+              "at": 130.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 109
+            },
+            {
+              "name": ":done",
+              "at": 131.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 112.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 136.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 113.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 136.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 111.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 135.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 140.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 163.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 117
+            },
+            {
+              "name": ":done",
+              "at": 140,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 122.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 147.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 123
+            },
+            {
+              "name": ":done",
+              "at": 146.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 109.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 133.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -4858,106 +5634,146 @@
       "1k items, 1 update each (sequentially, async)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=1000&percentRandomAwait=100",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 204.39999985694885
+              "at": 194.10000014305115
             },
             {
               "name": ":done",
-              "at": 863
+              "at": 228.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 201.40000009536743
+              "at": 194.59999990463257
             },
             {
               "name": ":done",
-              "at": 856.2999999523163
+              "at": 227.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 211.79999995231628
+              "at": 212.79999995231628
             },
             {
               "name": ":done",
-              "at": 845.5
+              "at": 248.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 192.10000014305115
+              "at": 187.60000014305115
             },
             {
               "name": ":done",
-              "at": 826.5
+              "at": 229.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 201.5
+              "at": 195
             },
             {
               "name": ":done",
-              "at": 864.9000000953674
+              "at": 230.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 206.60000014305115
+              "at": 204.59999990463257
             },
             {
               "name": ":done",
-              "at": 940.5
+              "at": 243.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 201.20000004768372
+              "at": 197.30000019073486
             },
             {
               "name": ":done",
-              "at": 832.7999999523163
+              "at": 241.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 199
+              "at": 209.29999995231628
             },
             {
               "name": ":done",
-              "at": 870.2999999523163
+              "at": 244.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 206.79999995231628
+              "at": 203.09999990463257
             },
             {
               "name": ":done",
-              "at": 829.7999999523163
+              "at": 239.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 196.70000004768372
+              "at": 198
             },
             {
               "name": ":done",
-              "at": 853.9000000953674
+              "at": 234.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -4966,106 +5782,146 @@
       "1k items, 1 update each (sequentially)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=1000&percentRandomAwait=0",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 211.09999990463257
+              "at": 207.5
             },
             {
               "name": ":done",
-              "at": 342.7999999523163
+              "at": 245.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 194.70000004768372
+              "at": 197.09999990463257
             },
             {
               "name": ":done",
-              "at": 319.7999999523163
+              "at": 229.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 206.89999985694885
+              "at": 195.5
             },
             {
               "name": ":done",
-              "at": 343.2999999523163
+              "at": 232.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 216.20000004768372
+              "at": 196.09999990463257
             },
             {
               "name": ":done",
-              "at": 341.2000000476837
+              "at": 233.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 191.70000004768372
+              "at": 206.39999985694885
             },
             {
               "name": ":done",
-              "at": 315.2999999523163
+              "at": 238,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 198.70000004768372
+              "at": 200.40000009536743
             },
             {
               "name": ":done",
-              "at": 330.89999985694885
+              "at": 236.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 201.29999995231628
+              "at": 195.70000004768372
             },
             {
               "name": ":done",
-              "at": 329.69999980926514
+              "at": 227.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 232.29999995231628
+              "at": 203.89999985694885
             },
             {
               "name": ":done",
-              "at": 356.09999990463257
+              "at": 239.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 206
+              "at": 211.20000004768372
             },
             {
               "name": ":done",
-              "at": 335.5
+              "at": 246.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 204.20000004768372
+              "at": 202.79999995231628
             },
             {
               "name": ":done",
-              "at": 336.10000014305115
+              "at": 241.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -5074,106 +5930,146 @@
       "1k items 1 update on 5% (random, async)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=50&random=true&percentRandomAwait=100",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 201.40000009536743
+              "at": 192.29999995231628
             },
             {
               "name": ":done",
-              "at": 331.30000019073486
+              "at": 209.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 232.30000019073486
+              "at": 202.60000014305115
             },
             {
               "name": ":done",
-              "at": 358.5
+              "at": 217.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 202.29999995231628
+              "at": 197.79999995231628
             },
             {
               "name": ":done",
-              "at": 332.2999999523163
+              "at": 214.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 207.60000014305115
+              "at": 204.29999995231628
             },
             {
               "name": ":done",
-              "at": 326.90000009536743
+              "at": 221,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 192.20000004768372
+              "at": 199.79999995231628
             },
             {
               "name": ":done",
-              "at": 324.2000000476837
+              "at": 218.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 226.5
+              "at": 203.89999985694885
             },
             {
               "name": ":done",
-              "at": 329.7000000476837
+              "at": 222.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 207.90000009536743
+              "at": 189.20000004768372
             },
             {
               "name": ":done",
-              "at": 322
+              "at": 206.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 212.40000009536743
+              "at": 193.20000004768372
             },
             {
               "name": ":done",
-              "at": 316.7000000476837
+              "at": 210.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 208.09999990463257
+              "at": 197.70000004768372
             },
             {
               "name": ":done",
-              "at": 311.7999999523163
+              "at": 211.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 198.39999985694885
+              "at": 207.29999995231628
             },
             {
               "name": ":done",
-              "at": 289.2999999523163
+              "at": 225.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -5182,56 +6078,76 @@
       "1k items 1 update on 5% (random)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=50&random=true&percentRandomAwait=0",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 199.60000014305115
+              "at": 203
             },
             {
               "name": ":done",
-              "at": 247.30000019073486
+              "at": 219.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 193.5
+              "at": 194.79999995231628
             },
             {
               "name": ":done",
-              "at": 241.40000009536743
+              "at": 213,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 203.5
+              "at": 195.5
             },
             {
               "name": ":done",
-              "at": 252.20000004768372
+              "at": 210.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 211.40000009536743
+              "at": 195
             },
             {
               "name": ":done",
-              "at": 261.2000000476837
+              "at": 214,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 197.29999995231628
+              "at": 207.5
             },
             {
               "name": ":done",
-              "at": 243
+              "at": 226.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -5241,47 +6157,67 @@
             },
             {
               "name": ":done",
-              "at": 249.19999980926514
+              "at": 225.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 212.59999990463257
+              "at": 201.90000009536743
             },
             {
               "name": ":done",
-              "at": 256.5
+              "at": 223.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 203.40000009536743
+              "at": 198.29999995231628
             },
             {
               "name": ":done",
-              "at": 246.70000004768372
+              "at": 217.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 202.40000009536743
+              "at": 188.5
             },
             {
               "name": ":done",
-              "at": 247.30000019073486
+              "at": 206.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 209
+              "at": 188.30000019073486
             },
             {
               "name": ":done",
-              "at": 254.5
+              "at": 205.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -5290,16 +6226,280 @@
       "1k items 1 update on 25% (random, async)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=250&random=true&percentRandomAwait=100",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 203
+              "at": 205.79999995231628
             },
             {
               "name": ":done",
-              "at": 497.59999990463257
+              "at": 230.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 221.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 244.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 228.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 250.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 209.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 231,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 198.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 221.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 195.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 216.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 194
+            },
+            {
+              "name": ":done",
+              "at": 214,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 202
+            },
+            {
+              "name": ":done",
+              "at": 223.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 193.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 213.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 230.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 252.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 25% (random)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 197.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 221.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 214.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 238.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 197.5
+            },
+            {
+              "name": ":done",
+              "at": 218,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 197.5
+            },
+            {
+              "name": ":done",
+              "at": 217.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 188.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 212,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 195.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 219.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 198.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 221.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 192.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 214.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 192
+            },
+            {
+              "name": ":done",
+              "at": 213.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -5309,195 +6509,11 @@
             },
             {
               "name": ":done",
-              "at": 456.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 218
-            },
-            {
-              "name": ":done",
-              "at": 490.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 209.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 499.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 203.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 468.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 217.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 514.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 193.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 459.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 210.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 494.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 204.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 481.30000019073486
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 214.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 492.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 25% (random)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 214.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 287.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 210.5
-            },
-            {
-              "name": ":done",
-              "at": 281.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 214.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 286
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 211
-            },
-            {
-              "name": ":done",
-              "at": 289.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 215
-            },
-            {
-              "name": ":done",
-              "at": 291.19999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 215.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 285.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 205.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 273.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 220.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 292.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 209.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 283.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 205.5
-            },
-            {
-              "name": ":done",
-              "at": 272.5
+              "at": 220.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -5506,272 +6522,20 @@
       "1 value, 1k consumers, 10k updates (bursts of 100)": {
         "app": "fan-out",
         "query": "&consumers=1000&updates=10000&burstSize=100",
-        "version": "7.3.0-alpha.5",
+        "version": "7.3.0-alpha.1",
         "times": [
           [
             {
               "name": ":start",
-              "at": 178.70000004768372
+              "at": 180
             },
             {
               "name": ":done",
-              "at": 1874
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 181.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1892.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 184.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 1570.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 173
-            },
-            {
-              "name": ":done",
-              "at": 1846.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 181.5
-            },
-            {
-              "name": ":done",
-              "at": 1918.9000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 184.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 1891.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 182.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 1887.5999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 181.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1845.3999998569489
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 184
-            },
-            {
-              "name": ":done",
-              "at": 1849.4000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 178.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 1863.9000000953674
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=1000",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 187.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 351
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 171.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 354.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 176
-            },
-            {
-              "name": ":done",
-              "at": 347
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 186.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 364.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 174.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 351.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 174.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 357.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 173.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 340.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 174.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 351
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 195.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 356
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 193.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 364.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (single burst)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=10000",
-        "version": "7.3.0-alpha.5",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 180.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 196.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 180.5
-            },
-            {
-              "name": ":done",
-              "at": 199.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 177.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 214.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 175.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 212.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 189
-            },
-            {
-              "name": ":done",
-              "at": 204.79999995231628
+              "at": 1495.6000001430511,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -5781,17 +6545,67 @@
             },
             {
               "name": ":done",
-              "at": 187.09999990463257
+              "at": 1317.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 185.60000014305115
+              "at": 177.20000004768372
             },
             {
               "name": ":done",
-              "at": 223.60000014305115
+              "at": 1588.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 197.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 1422.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 169.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1694.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 194.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 1629.1000001430511,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -5801,27 +6615,349 @@
             },
             {
               "name": ":done",
-              "at": 196.20000004768372
+              "at": 1547.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 176.60000014305115
+              "at": 176.40000009536743
             },
             {
               "name": ":done",
-              "at": 194.60000014305115
+              "at": 1351.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 189.10000014305115
+              "at": 179
             },
             {
               "name": ":done",
-              "at": 207
+              "at": 1551.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 172.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1368.5999999046326,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=1000",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 196.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 392.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 176.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 383.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 189
+            },
+            {
+              "name": ":done",
+              "at": 394.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 175.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 380.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 172.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 385.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 186.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 374.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 171.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 379.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 179.5
+            },
+            {
+              "name": ":done",
+              "at": 378.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 167.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 350.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 168.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 371.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (single burst)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=10000",
+        "version": "7.3.0-alpha.1",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 175.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 215,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 179.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 220.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 181
+            },
+            {
+              "name": ":done",
+              "at": 222.70000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 171.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 211.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 172.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 214.19999980926514,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 181.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 223.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 174.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 213.80000019073486,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 181.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 222,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 179.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 218.70000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 174.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 214.20000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -5837,36 +6973,40 @@
           [
             {
               "name": ":start",
-              "at": 125.20000004768372
+              "at": 107.70000004768372
             },
             {
               "name": "fps",
-              "at": 5209.299999952316,
-              "detail": 101.4
+              "at": 5182.799999952316,
+              "detail": 109.98036780319724
             },
             {
               "name": "fps",
-              "at": 10205.5,
-              "detail": 106.3
+              "at": 10182,
+              "detail": 118.2
             },
             {
               "name": "fps",
-              "at": 15206.400000095367,
-              "detail": 109.1
+              "at": 15192.5,
+              "detail": 118.6
             },
             {
               "name": "fps",
-              "at": 20209.200000047684,
-              "detail": 112.5
+              "at": 20175.299999952316,
+              "detail": 117.602352047041
             },
             {
               "name": "fps",
-              "at": 25205,
-              "detail": 109.9
+              "at": 25176,
+              "detail": 117.79554059739165
             },
             {
               "name": ":done",
-              "at": 25207
+              "at": 25176.799999952316,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -5881,101 +7021,141 @@
           [
             {
               "name": ":start",
-              "at": 110.09999990463257
+              "at": 102
             },
             {
               "name": ":done",
-              "at": 6892.299999952316
+              "at": 6454.900000095367,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 106.90000009536743
+              "at": 105.59999990463257
             },
             {
               "name": ":done",
-              "at": 6906
+              "at": 6223.699999809265,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 110.29999995231628
+              "at": 107.90000009536743
             },
             {
               "name": ":done",
-              "at": 6938.200000047684
+              "at": 6121.599999904633,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 109.79999995231628
+              "at": 101.60000014305115
             },
             {
               "name": ":done",
-              "at": 6516.599999904633
+              "at": 5629,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 103.79999995231628
+              "at": 113.89999985694885
             },
             {
               "name": ":done",
-              "at": 6830.900000095367
+              "at": 6814.299999952316,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 103.79999995231628
+              "at": 106.5
             },
             {
               "name": ":done",
-              "at": 6600.299999952316
+              "at": 6918.200000047684,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.5
+              "at": 99.5
             },
             {
               "name": ":done",
-              "at": 6023.799999952316
+              "at": 6621.599999904633,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 107.30000019073486
+              "at": 108.70000004768372
             },
             {
               "name": ":done",
-              "at": 6135.900000095367
+              "at": 6799.799999952316,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.89999985694885
+              "at": 99.30000019073486
             },
             {
               "name": ":done",
-              "at": 6007.899999856949
+              "at": 6665.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 104
+              "at": 101.39999985694885
             },
             {
               "name": ":done",
-              "at": 6913.899999856949
+              "at": 6713,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -5989,51 +7169,113 @@
           [
             {
               "name": ":start",
+              "at": 104.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 122.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 109.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 127.60000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 104.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 124.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 101.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 119.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
               "at": 110.5
             },
             {
               "name": ":done",
-              "at": 129.5
+              "at": 132.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 94.5
+              "at": 101
             },
             {
               "name": ":done",
-              "at": 112.5
+              "at": 117.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.29999995231628
+              "at": 99.59999990463257
             },
             {
               "name": ":done",
-              "at": 120.59999990463257
+              "at": 116.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102
+              "at": 104.29999995231628
             },
             {
               "name": ":done",
-              "at": 121.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 105.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 124.5
+              "at": 120.19999980926514,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -6043,47 +7285,25 @@
             },
             {
               "name": ":done",
-              "at": 127.10000014305115
+              "at": 116.80000019073486,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 105.79999995231628
+              "at": 98.39999985694885
             },
             {
               "name": ":done",
-              "at": 125.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 105.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 123.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 99.5
-            },
-            {
-              "name": ":done",
-              "at": 120.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 107
-            },
-            {
-              "name": ":done",
-              "at": 133.80000019073486
+              "at": 113.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6097,101 +7317,141 @@
           [
             {
               "name": ":start",
-              "at": 103.29999995231628
+              "at": 100
             },
             {
               "name": ":done",
-              "at": 117.60000014305115
+              "at": 111.20000004768372,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 105.70000004768372
+              "at": 99.39999985694885
             },
             {
               "name": ":done",
-              "at": 119.79999995231628
+              "at": 111.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.20000004768372
+              "at": 107.59999990463257
             },
             {
               "name": ":done",
-              "at": 115.79999995231628
+              "at": 116.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 106.79999995231628
+              "at": 100.90000009536743
             },
             {
               "name": ":done",
-              "at": 117.79999995231628
+              "at": 113.40000009536743,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 106.19999980926514
+              "at": 101.59999990463257
             },
             {
               "name": ":done",
-              "at": 119.09999990463257
+              "at": 112.89999985694885,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 111.39999985694885
+              "at": 111.20000004768372
             },
             {
               "name": ":done",
-              "at": 123.79999995231628
+              "at": 122.70000004768372,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 110.09999990463257
+              "at": 104
             },
             {
               "name": ":done",
-              "at": 121.40000009536743
+              "at": 115.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 103
+              "at": 95.79999995231628
             },
             {
               "name": ":done",
-              "at": 119.20000004768372
+              "at": 108,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.59999990463257
+              "at": 104.59999990463257
             },
             {
               "name": ":done",
-              "at": 117.5
+              "at": 117.29999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 104.19999980926514
+              "at": 100.5
             },
             {
               "name": ":done",
-              "at": 118.69999980926514
+              "at": 112.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6205,101 +7465,141 @@
           [
             {
               "name": ":start",
-              "at": 109
+              "at": 104.60000014305115
             },
             {
               "name": ":done",
-              "at": 516.2999999523163
+              "at": 523.7000000476837,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 100
+              "at": 107.89999985694885
             },
             {
               "name": ":done",
-              "at": 505.39999985694885
+              "at": 536.8999998569489,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 104.39999985694885
+              "at": 103.89999985694885
             },
             {
               "name": ":done",
-              "at": 513.5
+              "at": 506.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 105.59999990463257
+              "at": 100.40000009536743
             },
             {
               "name": ":done",
-              "at": 506.59999990463257
+              "at": 497.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 110
+              "at": 103.60000014305115
             },
             {
               "name": ":done",
-              "at": 505
+              "at": 509.10000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 113.59999990463257
+              "at": 100.10000014305115
             },
             {
               "name": ":done",
-              "at": 528.0999999046326
+              "at": 502.10000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 113.10000014305115
+              "at": 105.90000009536743
             },
             {
               "name": ":done",
-              "at": 523.4000000953674
+              "at": 543.7000000476837,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 105.70000004768372
+              "at": 107.29999995231628
             },
             {
               "name": ":done",
-              "at": 505.89999985694885
+              "at": 533.7999999523163,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.70000004768372
+              "at": 105
             },
             {
               "name": ":done",
-              "at": 488.40000009536743
+              "at": 496.7999999523163,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.10000014305115
+              "at": 100.39999985694885
             },
             {
               "name": ":done",
-              "at": 504.30000019073486
+              "at": 505.2999999523163,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6313,101 +7613,141 @@
           [
             {
               "name": ":start",
-              "at": 111.10000014305115
+              "at": 105.20000004768372
             },
             {
               "name": ":done",
-              "at": 220.20000004768372
+              "at": 213.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.30000019073486
+              "at": 105.20000004768372
             },
             {
               "name": ":done",
-              "at": 209.90000009536743
+              "at": 208.20000004768372,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 99.59999990463257
+              "at": 110.90000009536743
             },
             {
               "name": ":done",
-              "at": 201.89999985694885
+              "at": 219.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 101.09999990463257
+              "at": 102.69999980926514
             },
             {
               "name": ":done",
-              "at": 214.20000004768372
+              "at": 209.29999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 106.79999995231628
+              "at": 97
             },
             {
               "name": ":done",
-              "at": 211.90000009536743
+              "at": 205.29999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.70000004768372
+              "at": 102.5
             },
             {
               "name": ":done",
-              "at": 216.20000004768372
+              "at": 201.69999980926514,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 102.20000004768372
+              "at": 99.79999995231628
             },
             {
               "name": ":done",
-              "at": 209.60000014305115
+              "at": 203.69999980926514,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 100.5
+              "at": 111.59999990463257
             },
             {
               "name": ":done",
-              "at": 209.09999990463257
+              "at": 214.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 107.39999985694885
+              "at": 111.70000004768372
             },
             {
               "name": ":done",
-              "at": 218.79999995231628
+              "at": 217.70000004768372,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 108.19999980926514
+              "at": 101.40000009536743
             },
             {
               "name": ":done",
-              "at": 223.79999995231628
+              "at": 206,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6421,51 +7761,29 @@
           [
             {
               "name": ":start",
-              "at": 136.20000004768372
+              "at": 123
             },
             {
               "name": ":done",
-              "at": 216.30000019073486
+              "at": 179.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.39999985694885
+              "at": 130.90000009536743
             },
             {
               "name": ":done",
-              "at": 211.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 136.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 212.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 129.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 216.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 136.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 216.60000014305115
+              "at": 194.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -6475,47 +7793,109 @@
             },
             {
               "name": ":done",
-              "at": 208
+              "at": 195,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.69999980926514
+              "at": 127.79999995231628
             },
             {
               "name": ":done",
-              "at": 202.89999985694885
+              "at": 188.40000009536743,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.40000009536743
+              "at": 125.19999980926514
             },
             {
               "name": ":done",
-              "at": 202.5
+              "at": 188.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 142.40000009536743
+              "at": 130.20000004768372
             },
             {
               "name": ":done",
-              "at": 227.90000009536743
+              "at": 191.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.5
+              "at": 127.10000014305115
             },
             {
               "name": ":done",
-              "at": 220.09999990463257
+              "at": 191.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 125.5
+            },
+            {
+              "name": ":done",
+              "at": 211.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 124.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 191,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 123.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 186.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6529,71 +7909,57 @@
           [
             {
               "name": ":start",
-              "at": 129.20000004768372
+              "at": 127.79999995231628
             },
             {
               "name": ":done",
-              "at": 201.60000014305115
+              "at": 183,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 132.79999995231628
+              "at": 126.90000009536743
             },
             {
               "name": ":done",
-              "at": 207.40000009536743
+              "at": 192.40000009536743,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 129.29999995231628
+              "at": 122.60000014305115
             },
             {
               "name": ":done",
-              "at": 200.29999995231628
+              "at": 180.40000009536743,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.70000004768372
+              "at": 125.5
             },
             {
               "name": ":done",
-              "at": 208.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 137.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 209.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 135.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 205.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 131.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 230.59999990463257
+              "at": 184,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -6603,27 +7969,81 @@
             },
             {
               "name": ":done",
-              "at": 194.79999995231628
+              "at": 186.60000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 132.39999985694885
+              "at": 127.09999990463257
             },
             {
               "name": ":done",
-              "at": 224.79999995231628
+              "at": 206,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.80000019073486
+              "at": 132.5
             },
             {
               "name": ":done",
-              "at": 203
+              "at": 208.40000009536743,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 127
+            },
+            {
+              "name": ":done",
+              "at": 190.09999990463257,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 122.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 182.10000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 121.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 178.29999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6637,91 +8057,127 @@
           [
             {
               "name": ":start",
-              "at": 126.20000004768372
+              "at": 128.09999990463257
             },
             {
               "name": ":done",
-              "at": 164.40000009536743
+              "at": 148.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128
+              "at": 135.70000004768372
             },
             {
               "name": ":done",
-              "at": 164.79999995231628
+              "at": 156.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126
+              "at": 128.20000004768372
             },
             {
               "name": ":done",
-              "at": 143.5
+              "at": 173,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.39999985694885
+              "at": 124.29999995231628
             },
             {
               "name": ":done",
-              "at": 159.20000004768372
+              "at": 163.79999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.79999995231628
+              "at": 124.40000009536743
             },
             {
               "name": ":done",
-              "at": 147
+              "at": 141.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.89999985694885
+              "at": 129.79999995231628
             },
             {
               "name": ":done",
-              "at": 164.59999990463257
+              "at": 146.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 142.80000019073486
+              "at": 129.40000009536743
             },
             {
               "name": ":done",
-              "at": 176.5
+              "at": 167.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.59999990463257
+              "at": 121.59999990463257
             },
             {
               "name": ":done",
-              "at": 166
+              "at": 161.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 125.79999995231628
+              "at": 129.5
             },
             {
               "name": ":done",
-              "at": 161.90000009536743
+              "at": 149,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -6731,7 +8187,11 @@
             },
             {
               "name": ":done",
-              "at": 149.79999995231628
+              "at": 149.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6745,101 +8205,141 @@
           [
             {
               "name": ":start",
+              "at": 127.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 147.79999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 126.5
+            },
+            {
+              "name": ":done",
+              "at": 147.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 129.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 147.79999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 127.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 145.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 125.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 145.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
               "at": 128.60000014305115
             },
             {
               "name": ":done",
-              "at": 149.20000004768372
+              "at": 150.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.70000004768372
+              "at": 125.59999990463257
             },
             {
               "name": ":done",
-              "at": 161.20000004768372
+              "at": 144.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.10000014305115
+              "at": 126.30000019073486
             },
             {
               "name": ":done",
-              "at": 164.29999995231628
+              "at": 145.60000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.79999995231628
+              "at": 121.5
             },
             {
               "name": ":done",
-              "at": 164.59999990463257
+              "at": 139.5,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.89999985694885
+              "at": 120.39999985694885
             },
             {
               "name": ":done",
-              "at": 167.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 138.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 172.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 129.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 152.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 132.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 153
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 130.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 168
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 134.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 170.79999995231628
+              "at": 140.89999985694885,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6853,101 +8353,141 @@
           [
             {
               "name": ":start",
-              "at": 127.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 160
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 124.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 167.30000019073486
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 137.5
-            },
-            {
-              "name": ":done",
-              "at": 189.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 131.5
-            },
-            {
-              "name": ":done",
-              "at": 184.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 132.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 178.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 141.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 193.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 132.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 162.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 133.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 183.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 125
-            },
-            {
-              "name": ":done",
-              "at": 170.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
               "at": 127
             },
             {
               "name": ":done",
-              "at": 176.39999985694885
+              "at": 157.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 123
+            },
+            {
+              "name": ":done",
+              "at": 157.30000019073486,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 123.5
+            },
+            {
+              "name": ":done",
+              "at": 151.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 123.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 155.30000019073486,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 134.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 166,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 120.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 152.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 131.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 127.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 159,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 127.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 156.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 124.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 154.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -6961,101 +8501,141 @@
           [
             {
               "name": ":start",
-              "at": 144.80000019073486
+              "at": 120.59999990463257
             },
             {
               "name": ":done",
-              "at": 189.60000014305115
+              "at": 148.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.5
+              "at": 117.09999990463257
             },
             {
               "name": ":done",
-              "at": 157
+              "at": 144.89999985694885,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 136.79999995231628
+              "at": 124.79999995231628
             },
             {
               "name": ":done",
-              "at": 171.5
+              "at": 154.29999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 133.80000019073486
+              "at": 121.80000019073486
             },
             {
               "name": ":done",
-              "at": 167.70000004768372
+              "at": 152,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 133.79999995231628
+              "at": 135.09999990463257
             },
             {
               "name": ":done",
-              "at": 180.5
+              "at": 164.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 137.5
+              "at": 130.20000004768372
             },
             {
               "name": ":done",
-              "at": 182.70000004768372
+              "at": 159,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.09999990463257
+              "at": 131.60000014305115
             },
             {
               "name": ":done",
-              "at": 163.19999980926514
+              "at": 164.79999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 129
+              "at": 140.20000004768372
             },
             {
               "name": ":done",
-              "at": 174.5
+              "at": 173.60000014305115,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 130.29999995231628
+              "at": 128.10000014305115
             },
             {
               "name": ":done",
-              "at": 179.79999995231628
+              "at": 159.70000004768372,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.09999990463257
+              "at": 127.89999985694885
             },
             {
               "name": ":done",
-              "at": 177.09999990463257
+              "at": 156.79999995231628,
+              "detail": {
+                "checks": 3,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -7069,101 +8649,141 @@
           [
             {
               "name": ":start",
-              "at": 130
+              "at": 137.09999990463257
             },
             {
               "name": ":done",
-              "at": 1596.1999998092651
+              "at": 1651.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 143.79999995231628
+              "at": 128
             },
             {
               "name": ":done",
-              "at": 1594
+              "at": 1565.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.29999995231628
+              "at": 128
             },
             {
               "name": ":done",
-              "at": 1559.2000000476837
+              "at": 1609.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 133.5
+              "at": 125.29999995231628
             },
             {
               "name": ":done",
-              "at": 1422.6999998092651
+              "at": 1496.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 137.29999995231628
+              "at": 124.29999995231628
             },
             {
               "name": ":done",
-              "at": 1589.5
+              "at": 1510.4000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 134
+              "at": 130.5
             },
             {
               "name": ":done",
-              "at": 1619.6000001430511
+              "at": 1570.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 124.10000014305115
+              "at": 144.10000014305115
             },
             {
               "name": ":done",
-              "at": 1526.1000001430511
+              "at": 1524.3000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 139.59999990463257
+              "at": 126.20000004768372
             },
             {
               "name": ":done",
-              "at": 1585
+              "at": 1447.9000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.20000004768372
+              "at": 138.79999995231628
             },
             {
               "name": ":done",
-              "at": 1506.8000001907349
+              "at": 1594.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 130.09999990463257
+              "at": 129.5
             },
             {
               "name": ":done",
-              "at": 1542.8999998569489
+              "at": 1500.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -7177,101 +8797,141 @@
           [
             {
               "name": ":start",
-              "at": 132.89999985694885
+              "at": 133.20000004768372
             },
             {
               "name": ":done",
-              "at": 306.19999980926514
+              "at": 314.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 132
+              "at": 126.39999985694885
             },
             {
               "name": ":done",
-              "at": 292.7999999523163
+              "at": 297,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 129.29999995231628
+              "at": 121.79999995231628
             },
             {
               "name": ":done",
-              "at": 302
+              "at": 284.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.20000004768372
+              "at": 149.39999985694885
             },
             {
               "name": ":done",
-              "at": 308.2000000476837
+              "at": 303.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 125.29999995231628
+              "at": 132.10000014305115
             },
             {
               "name": ":done",
-              "at": 300.7000000476837
+              "at": 335.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 129.59999990463257
+              "at": 130.09999990463257
             },
             {
               "name": ":done",
-              "at": 322.7999999523163
+              "at": 326.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126.29999995231628
+              "at": 130.5
             },
             {
               "name": ":done",
-              "at": 324.89999985694885
+              "at": 303.60000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 158.79999995231628
+              "at": 127.40000009536743
             },
             {
               "name": ":done",
-              "at": 343
+              "at": 300,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 140
+              "at": 129.39999985694885
             },
             {
               "name": ":done",
-              "at": 324.2000000476837
+              "at": 289.19999980926514,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 128.80000019073486
+              "at": 129.79999995231628
             },
             {
               "name": ":done",
-              "at": 308.80000019073486
+              "at": 320.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -7285,101 +8945,141 @@
           [
             {
               "name": ":start",
-              "at": 129
+              "at": 125.39999985694885
             },
             {
               "name": ":done",
-              "at": 219.80000019073486
+              "at": 162.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 139.60000014305115
+              "at": 136.5
             },
             {
               "name": ":done",
-              "at": 205.30000019073486
+              "at": 174.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 129.69999980926514
+              "at": 129.89999985694885
             },
             {
               "name": ":done",
-              "at": 196.59999990463257
+              "at": 168.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 136.59999990463257
+              "at": 123.10000014305115
             },
             {
               "name": ":done",
-              "at": 211
+              "at": 158.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 135
+              "at": 134.90000009536743
             },
             {
               "name": ":done",
-              "at": 202.5
+              "at": 175.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.40000009536743
+              "at": 129.10000014305115
             },
             {
               "name": ":done",
-              "at": 202.60000014305115
+              "at": 166,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 137.09999990463257
+              "at": 123.10000014305115
             },
             {
               "name": ":done",
-              "at": 208.39999985694885
+              "at": 158.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 135.39999985694885
+              "at": 130.90000009536743
             },
             {
               "name": ":done",
-              "at": 207.29999995231628
+              "at": 171.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 132.79999995231628
+              "at": 131.89999985694885
             },
             {
               "name": ":done",
-              "at": 207.5
+              "at": 173.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 134
+              "at": 133.20000004768372
             },
             {
               "name": ":done",
-              "at": 203.60000014305115
+              "at": 177,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -7390,41 +9090,45 @@
       "DB Monitor w/ chat simulation": {
         "app": "dbmon-with-chat",
         "query": "",
-        "version": "2.0.0-beta.21",
+        "version": "2.0.0-beta.27",
         "times": [
           [
             {
               "name": ":start",
-              "at": 61.200000047683716
+              "at": 60.200000047683716
             },
             {
               "name": "fps",
-              "at": 5150.900000095367,
-              "detail": 73.3
+              "at": 5143.299999952316,
+              "detail": 113.57707589196131
             },
             {
               "name": "fps",
-              "at": 10159.200000047684,
-              "detail": 76.3
+              "at": 10137.5,
+              "detail": 117.1945429412825
             },
             {
               "name": "fps",
-              "at": 15157.200000047684,
-              "detail": 84.2
+              "at": 15142.299999952316,
+              "detail": 117.4
             },
             {
               "name": "fps",
-              "at": 20151,
-              "detail": 81.6
+              "at": 20146.200000047684,
+              "detail": 115.19121742091875
             },
             {
               "name": "fps",
-              "at": 25152.200000047684,
-              "detail": 89.7
+              "at": 25140,
+              "detail": 117.2
             },
             {
               "name": ":done",
-              "at": 25154.200000047684
+              "at": 25140.89999985695,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -7434,302 +9138,76 @@
       "Incrementing Render Effect": {
         "app": "incrementing-render-effect",
         "query": "&updates=100000",
-        "version": "2.0.0-beta.21",
+        "version": "2.0.0-beta.27",
         "times": [
           [
             {
               "name": ":start",
-              "at": 46.200000047683716
+              "at": 45.5
             },
             {
               "name": ":done",
-              "at": 960.8999998569489
+              "at": 944,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.39999985694885
+              "at": 48.5
             },
             {
               "name": ":done",
-              "at": 806.7999999523163
+              "at": 784.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 45.09999990463257
+              "at": 48.299999952316284
             },
             {
               "name": ":done",
-              "at": 812.0999999046326
+              "at": 783.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 45.200000047683716
+              "at": 42.5
             },
             {
               "name": ":done",
-              "at": 820.4000000953674
+              "at": 780.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.10000014305115
+              "at": 43
             },
             {
               "name": ":done",
-              "at": 826.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 49.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 818.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 828.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 47.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 830.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 46
-            },
-            {
-              "name": ":done",
-              "at": 819.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 47.799999952316284
-            },
-            {
-              "name": ":done",
-              "at": 809
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 1k updates (async)": {
-        "app": "one-item-many-updates",
-        "query": "&updates=1000&percentRandomAwait=100",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 48.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 74.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 53
-            },
-            {
-              "name": ":done",
-              "at": 78.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.200000047683716
-            },
-            {
-              "name": ":done",
-              "at": 71.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 47.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 74
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 51.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 76.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 46
-            },
-            {
-              "name": ":done",
-              "at": 74
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 49.200000047683716
-            },
-            {
-              "name": ":done",
-              "at": 80.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.5
-            },
-            {
-              "name": ":done",
-              "at": 73.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.799999952316284
-            },
-            {
-              "name": ":done",
-              "at": 72.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 47.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 79.19999980926514
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 1k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=1000&percentRandomAwait=0",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 53.700000047683716
-            },
-            {
-              "name": ":done",
-              "at": 58.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 42
-            },
-            {
-              "name": ":done",
-              "at": 52.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 46.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 54.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 45.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 54.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 46.200000047683716
-            },
-            {
-              "name": ":done",
-              "at": 55.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 43.5
-            },
-            {
-              "name": ":done",
-              "at": 52.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 43.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 53.700000047683716
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 50.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 56.10000014305115
+              "at": 762.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -7739,223 +9217,39 @@
             },
             {
               "name": ":done",
-              "at": 53.40000009536743
+              "at": 757,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.200000047683716
+              "at": 44.09999990463257
             },
             {
               "name": ":done",
-              "at": 55.80000019073486
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates (async)": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=100",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 46.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 583.9000000953674
+              "at": 771.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 40.700000047683716
+              "at": 41.799999952316284
             },
             {
               "name": ":done",
-              "at": 596.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 45.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 589.7000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 42.700000047683716
-            },
-            {
-              "name": ":done",
-              "at": 563.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 610.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 43.5
-            },
-            {
-              "name": ":done",
-              "at": 593.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.299999952316284
-            },
-            {
-              "name": ":done",
-              "at": 606.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 42.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 595.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 48.799999952316284
-            },
-            {
-              "name": ":done",
-              "at": 581.6000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 43.799999952316284
-            },
-            {
-              "name": ":done",
-              "at": 566.3999998569489
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 item, 100k updates": {
-        "app": "one-item-many-updates",
-        "query": "&updates=100000&percentRandomAwait=0",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 49.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 65.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 55.200000047683716
-            },
-            {
-              "name": ":done",
-              "at": 65.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 46.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 62.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 45.200000047683716
-            },
-            {
-              "name": ":done",
-              "at": 61.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 43.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 65.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 40.299999952316284
-            },
-            {
-              "name": ":done",
-              "at": 56
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 59.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 44.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 60.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 41.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 57
+              "at": 775.6999998092651,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -7965,7 +9259,617 @@
             },
             {
               "name": ":done",
-              "at": 60.90000009536743
+              "at": 763.3000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.5
+            },
+            {
+              "name": ":done",
+              "at": 763.8000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 1k updates (async)": {
+        "app": "one-item-many-updates",
+        "query": "&updates=1000&percentRandomAwait=100",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 42.5
+            },
+            {
+              "name": ":done",
+              "at": 58.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.700000047683716
+            },
+            {
+              "name": ":done",
+              "at": 61.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 61,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 63.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.299999952316284
+            },
+            {
+              "name": ":done",
+              "at": 58.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 61.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 84.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 63.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.200000047683716
+            },
+            {
+              "name": ":done",
+              "at": 58.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 59.799999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 1k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=1000&percentRandomAwait=0",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 46.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 51.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 47.5
+            },
+            {
+              "name": ":done",
+              "at": 52.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45
+            },
+            {
+              "name": ":done",
+              "at": 49.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 38.5
+            },
+            {
+              "name": ":done",
+              "at": 43.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 48,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.200000047683716
+            },
+            {
+              "name": ":done",
+              "at": 50.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 41.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 46.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.200000047683716
+            },
+            {
+              "name": ":done",
+              "at": 49.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 51.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 55.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 59.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates (async)": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=100",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 46.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 537.6000001430511,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 44.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 549.4000000953674,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 50
+            },
+            {
+              "name": ":done",
+              "at": 574.4000000953674,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 52.299999952316284
+            },
+            {
+              "name": ":done",
+              "at": 561.2999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.700000047683716
+            },
+            {
+              "name": ":done",
+              "at": 563.1000001430511,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45
+            },
+            {
+              "name": ":done",
+              "at": 540,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 43.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 524.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 51.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 548.9000000953674,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 525.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 534.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 item, 100k updates": {
+        "app": "one-item-many-updates",
+        "query": "&updates=100000&percentRandomAwait=0",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 42.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 54.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 49.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 59.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 47.200000047683716
+            },
+            {
+              "name": ":done",
+              "at": 58,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.5
+            },
+            {
+              "name": ":done",
+              "at": 58.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 58.700000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 53.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.299999952316284
+            },
+            {
+              "name": ":done",
+              "at": 54.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 44.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 55.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 46.299999952316284
+            },
+            {
+              "name": ":done",
+              "at": 58.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 42.799999952316284
+            },
+            {
+              "name": ":done",
+              "at": 55.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -7974,440 +9878,78 @@
       "1k items, 1 update each (sequentially, async)": {
         "app": "ten-k-items-one-time",
         "query": "&items=1000&updates=1000&percentRandomAwait=100",
-        "version": "2.0.0-beta.21",
+        "version": "2.0.0-beta.27",
         "times": [
           [
             {
               "name": ":start",
-              "at": 72
+              "at": 81.39999985694885
             },
             {
               "name": ":done",
-              "at": 1609.0999999046326
+              "at": 432,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 71.20000004768372
+              "at": 80.40000009536743
             },
             {
               "name": ":done",
-              "at": 1686.8999998569489
+              "at": 421.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 69.20000004768372
+              "at": 81.39999985694885
             },
             {
               "name": ":done",
-              "at": 1600.7000000476837
+              "at": 446.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 70.20000004768372
+              "at": 75.59999990463257
             },
             {
               "name": ":done",
-              "at": 1600.3999998569489
+              "at": 433.2000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 73.89999985694885
+              "at": 81.5
             },
             {
               "name": ":done",
-              "at": 1628
+              "at": 451.2000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
-          [
-            {
-              "name": ":start",
-              "at": 88.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1693.4000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 1654.8000001907349
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 1638.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 78.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1587.1000001430511
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71.5
-            },
-            {
-              "name": ":done",
-              "at": 1656.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items, 1 update each (sequentially)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=1000&percentRandomAwait=0",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 69.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 115.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 97.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 146.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 124.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 121.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 103.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71
-            },
-            {
-              "name": ":done",
-              "at": 118.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 68.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 128.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 86.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 132.69999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 119.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72
-            },
-            {
-              "name": ":done",
-              "at": 123.69999980926514
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 5% (random, async)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=50&random=true&percentRandomAwait=100",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 69.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 202.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 69
-            },
-            {
-              "name": ":done",
-              "at": 194.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 208.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 201
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 202.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 67.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 189.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 197
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 69.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 230.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 195.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 212.5
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 5% (random)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=50&random=true&percentRandomAwait=0",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 76.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 91.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 112
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 90.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 107.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 69.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 105.20000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 71.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 108.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 108.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 90.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 68.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 108.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73
-            },
-            {
-              "name": ":done",
-              "at": 112.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 105.29999995231628
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 25% (random, async)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=250&random=true&percentRandomAwait=100",
-        "version": "2.0.0-beta.21",
-        "times": [
           [
             {
               "name": ":start",
@@ -8415,431 +9957,27 @@
             },
             {
               "name": ":done",
-              "at": 486.40000009536743
+              "at": 424.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 71.20000004768372
+              "at": 81.5
             },
             {
               "name": ":done",
-              "at": 509.09999990463257
+              "at": 460.2000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
-          [
-            {
-              "name": ":start",
-              "at": 69.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 497.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 493.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 471.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 495.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 79.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 525.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 503.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72
-            },
-            {
-              "name": ":done",
-              "at": 501
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 498.2000000476837
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1k items 1 update on 25% (random)": {
-        "app": "ten-k-items-one-time",
-        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 71
-            },
-            {
-              "name": ":done",
-              "at": 92.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 112.19999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 72.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 122.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 67.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 89.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 109.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 70.19999980926514
-            },
-            {
-              "name": ":done",
-              "at": 128.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 77.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 114.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 73.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 118.69999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 91.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 136.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 68.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 114.19999980926514
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (bursts of 100)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=100",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 82.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1396.4000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 81
-            },
-            {
-              "name": ":done",
-              "at": 1442
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 83.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 1326.3999998569489
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 88.5
-            },
-            {
-              "name": ":done",
-              "at": 1408.0999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 81.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 1368.3999998569489
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 82
-            },
-            {
-              "name": ":done",
-              "at": 1404.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 83.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 1283
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 91.30000019073486
-            },
-            {
-              "name": ":done",
-              "at": 1424.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 88.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1418.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 83.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1392.9000000953674
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=1000",
-        "version": "2.0.0-beta.21",
-        "times": [
-          [
-            {
-              "name": ":start",
-              "at": 77.5
-            },
-            {
-              "name": ":done",
-              "at": 399.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 103.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 432.80000019073486
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 88.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 368.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 85.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 407.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 85.5
-            },
-            {
-              "name": ":done",
-              "at": 381.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 79.40000009536743
-            },
-            {
-              "name": ":done",
-              "at": 368.2000000476837
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 82
-            },
-            {
-              "name": ":done",
-              "at": 367.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 85.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 385.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 85.69999980926514
-            },
-            {
-              "name": ":done",
-              "at": 380.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 81.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 417.89999985694885
-            }
-          ]
-        ],
-        "whatsBetter": "smaller"
-      },
-      "1 value, 1k consumers, 10k updates (single burst)": {
-        "app": "fan-out",
-        "query": "&consumers=1000&updates=10000&burstSize=10000",
-        "version": "2.0.0-beta.21",
-        "times": [
           [
             {
               "name": ":start",
@@ -8847,37 +9985,25 @@
             },
             {
               "name": ":done",
-              "at": 248.89999985694885
+              "at": 423.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 84.70000004768372
+              "at": 77.70000004768372
             },
             {
               "name": ":done",
-              "at": 297.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 81
-            },
-            {
-              "name": ":done",
-              "at": 290.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 83.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 281.19999980926514
+              "at": 426.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -8887,27 +10013,89 @@
             },
             {
               "name": ":done",
-              "at": 275
+              "at": 433.2000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items, 1 update each (sequentially)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=1000&percentRandomAwait=0",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 81.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 105,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 84.5
+              "at": 82.10000014305115
             },
             {
               "name": ":done",
-              "at": 279.40000009536743
+              "at": 104.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79.29999995231628
+              "at": 82.79999995231628
             },
             {
               "name": ":done",
-              "at": 284.5
+              "at": 102.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 103,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 103.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -8917,27 +10105,1103 @@
             },
             {
               "name": ":done",
-              "at": 280.09999990463257
+              "at": 102.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 81.79999995231628
+              "at": 85.90000009536743
             },
             {
               "name": ":done",
-              "at": 272.09999990463257
+              "at": 108.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 87.09999990463257
+              "at": 86
             },
             {
               "name": ":done",
-              "at": 279.90000009536743
+              "at": 107.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 84.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 103.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 84.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 102.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 5% (random, async)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=50&random=true&percentRandomAwait=100",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 80.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 111.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 108.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 110.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 107.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 107.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 80.5
+            },
+            {
+              "name": ":done",
+              "at": 107.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 103.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.5
+            },
+            {
+              "name": ":done",
+              "at": 113.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 112.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 87.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 5% (random)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=50&random=true&percentRandomAwait=0",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 86.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 93.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 86.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 95,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 101.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 107.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 85.5
+            },
+            {
+              "name": ":done",
+              "at": 93.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 86.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 86.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81
+            },
+            {
+              "name": ":done",
+              "at": 89.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 89.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 85.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 92.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 87,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 25% (random, async)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=250&random=true&percentRandomAwait=100",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 81.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 185.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 105
+            },
+            {
+              "name": ":done",
+              "at": 200.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 176.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 175.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 178.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 80.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 177.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 75.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 174,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.5
+            },
+            {
+              "name": ":done",
+              "at": 184.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 183.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 84.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 180.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1k items 1 update on 25% (random)": {
+        "app": "ten-k-items-one-time",
+        "query": "&items=1000&updates=250&random=true&percentRandomAwait=0",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 86.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 100.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79
+            },
+            {
+              "name": ":done",
+              "at": 93.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 97.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 97.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 99.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 85.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 99.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 94,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 97.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 96,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 97,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (bursts of 100)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=100",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 75.5
+            },
+            {
+              "name": ":done",
+              "at": 1294.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 1138.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 1249.8000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 1276.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 105.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 1296,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 86
+            },
+            {
+              "name": ":done",
+              "at": 1433,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 75.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 1337.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1271.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 1244.9000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.19999980926514
+            },
+            {
+              "name": ":done",
+              "at": 1294.1999998092651,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (bursts of 1000)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=1000",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 74.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 382.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78
+            },
+            {
+              "name": ":done",
+              "at": 359.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76.5
+            },
+            {
+              "name": ":done",
+              "at": 354.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 389.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 72.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 351,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 382.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 351.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 362.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 74.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 378.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 87
+            },
+            {
+              "name": ":done",
+              "at": 402.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ]
+        ],
+        "whatsBetter": "smaller"
+      },
+      "1 value, 1k consumers, 10k updates (single burst)": {
+        "app": "fan-out",
+        "query": "&consumers=1000&updates=10000&burstSize=10000",
+        "version": "2.0.0-beta.27",
+        "times": [
+          [
+            {
+              "name": ":start",
+              "at": 78.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 244.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 79.5
+            },
+            {
+              "name": ":done",
+              "at": 246.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 81.69999980926514
+            },
+            {
+              "name": ":done",
+              "at": 239.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 248.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76
+            },
+            {
+              "name": ":done",
+              "at": 251.80000019073486,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.5
+            },
+            {
+              "name": ":done",
+              "at": 254.20000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 247.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 265.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 247.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 247.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -8953,36 +11217,40 @@
           [
             {
               "name": ":start",
-              "at": 64.29999995231628
+              "at": 61
             },
             {
               "name": "fps",
-              "at": 5139.899999856949,
-              "detail": 116.3
+              "at": 5136.5,
+              "detail": 116.8
             },
             {
               "name": "fps",
-              "at": 10141.399999856949,
-              "detail": 118.9
+              "at": 10135.799999952316,
+              "detail": 117.4
             },
             {
               "name": "fps",
-              "at": 15140.099999904633,
-              "detail": 119.3
+              "at": 15137.599999904633,
+              "detail": 118.3965382535008
             },
             {
               "name": "fps",
-              "at": 20136.39999985695,
-              "detail": 117.3
+              "at": 20136.89999985695,
+              "detail": 119.60239204784094
             },
             {
               "name": "fps",
-              "at": 25141.299999952316,
-              "detail": 117.5
+              "at": 25140.39999985695,
+              "detail": 119.99919866979184
             },
             {
               "name": ":done",
-              "at": 25142.5
+              "at": 25141.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -8997,71 +11265,113 @@
           [
             {
               "name": ":start",
-              "at": 52.40000009536743
+              "at": 50.40000009536743
             },
             {
               "name": ":done",
-              "at": 1327
+              "at": 1261.4000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.40000009536743
+              "at": 47.59999990463257
             },
             {
               "name": ":done",
-              "at": 1158.4000000953674
+              "at": 1200.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 48.60000014305115
+              "at": 49.799999952316284
             },
             {
               "name": ":done",
-              "at": 1157.2999999523163
+              "at": 1165.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.299999952316284
+              "at": 46.09999990463257
             },
             {
               "name": ":done",
-              "at": 1209
+              "at": 1143.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 48.90000009536743
+              "at": 48.09999990463257
             },
             {
               "name": ":done",
-              "at": 1201.2000000476837
+              "at": 1119.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 48.200000047683716
+              "at": 51
             },
             {
               "name": ":done",
-              "at": 1158.7000000476837
+              "at": 1161.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.59999990463257
+              "at": 52.200000047683716
             },
             {
               "name": ":done",
-              "at": 1167.4000000953674
+              "at": 1143.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 52
+            },
+            {
+              "name": ":done",
+              "at": 1160.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
@@ -9071,27 +11381,25 @@
             },
             {
               "name": ":done",
-              "at": 1153.4000000953674
+              "at": 1193.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50
+              "at": 52.299999952316284
             },
             {
               "name": ":done",
-              "at": 1167
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 49.5
-            },
-            {
-              "name": ":done",
-              "at": 1148.2999999523163
+              "at": 1172.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -9105,101 +11413,141 @@
           [
             {
               "name": ":start",
-              "at": 54.40000009536743
+              "at": 60.5
             },
             {
               "name": ":done",
-              "at": 90.20000004768372
+              "at": 98.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.799999952316284
+              "at": 47.5
             },
             {
               "name": ":done",
-              "at": 117.29999995231628
+              "at": 79.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.799999952316284
+              "at": 49.59999990463257
             },
             {
               "name": ":done",
-              "at": 91.90000009536743
+              "at": 75.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.299999952316284
+              "at": 50.5
             },
             {
               "name": ":done",
-              "at": 88.40000009536743
+              "at": 77.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.80000019073486
+              "at": 49.60000014305115
             },
             {
               "name": ":done",
-              "at": 87.60000014305115
+              "at": 98.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 48.5
+              "at": 49.200000047683716
             },
             {
               "name": ":done",
-              "at": 84.90000009536743
+              "at": 76.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.700000047683716
+              "at": 47.700000047683716
             },
             {
               "name": ":done",
-              "at": 88.70000004768372
+              "at": 81,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.5
+              "at": 49.60000014305115
             },
             {
               "name": ":done",
-              "at": 83.29999995231628
+              "at": 79.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.60000014305115
+              "at": 49.89999985694885
             },
             {
               "name": ":done",
-              "at": 85.90000009536743
+              "at": 78,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.30000019073486
+              "at": 51.39999985694885
             },
             {
               "name": ":done",
-              "at": 119.30000019073486
+              "at": 78.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9213,101 +11561,141 @@
           [
             {
               "name": ":start",
-              "at": 50.299999952316284
-            },
-            {
-              "name": ":done",
-              "at": 59.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 58.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 64.69999980926514
-            }
-          ],
-          [
-            {
-              "name": ":start",
               "at": 48.799999952316284
             },
             {
               "name": ":done",
-              "at": 70.09999990463257
+              "at": 55.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 57.60000014305115
+              "at": 54.60000014305115
             },
             {
               "name": ":done",
-              "at": 73.70000004768372
+              "at": 61.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.299999952316284
+              "at": 46.39999985694885
             },
             {
               "name": ":done",
-              "at": 63.799999952316284
+              "at": 52.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.59999990463257
+              "at": 48.700000047683716
             },
             {
               "name": ":done",
-              "at": 66
+              "at": 54.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.09999990463257
+              "at": 47.200000047683716
             },
             {
               "name": ":done",
-              "at": 68.5
+              "at": 53.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.10000014305115
+              "at": 51.700000047683716
             },
             {
               "name": ":done",
-              "at": 61.40000009536743
+              "at": 57.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.200000047683716
+              "at": 47.40000009536743
             },
             {
               "name": ":done",
-              "at": 58.299999952316284
+              "at": 53.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.09999990463257
+              "at": 51.90000009536743
             },
             {
               "name": ":done",
-              "at": 59.69999980926514
+              "at": 57.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 54.5
+            },
+            {
+              "name": ":done",
+              "at": 58.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 45.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 51.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9321,101 +11709,141 @@
           [
             {
               "name": ":start",
-              "at": 50.09999990463257
+              "at": 48
             },
             {
               "name": ":done",
-              "at": 1003
+              "at": 960.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.10000014305115
+              "at": 49.59999990463257
             },
             {
               "name": ":done",
-              "at": 991.1000001430511
+              "at": 1001.0999999046326,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.200000047683716
+              "at": 49.799999952316284
             },
             {
               "name": ":done",
-              "at": 994.5
+              "at": 975.1000001430511,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.90000009536743
+              "at": 47.299999952316284
             },
             {
               "name": ":done",
-              "at": 968.2000000476837
+              "at": 975.4000000953674,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 48.09999990463257
+              "at": 52
             },
             {
               "name": ":done",
-              "at": 986
+              "at": 969.3000001907349,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.700000047683716
+              "at": 48.5
             },
             {
               "name": ":done",
-              "at": 980.2999999523163
+              "at": 991.2999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.39999985694885
+              "at": 49.5
             },
             {
               "name": ":done",
-              "at": 1055.3999998569489
+              "at": 994.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.39999985694885
+              "at": 47.19999980926514
             },
             {
               "name": ":done",
-              "at": 966.8999998569489
+              "at": 985.8999998569489,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 72.60000014305115
+              "at": 56.299999952316284
             },
             {
               "name": ":done",
-              "at": 986.7000000476837
+              "at": 955.2999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.10000014305115
+              "at": 51
             },
             {
               "name": ":done",
-              "at": 991.7000000476837
+              "at": 974.5999999046326,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9429,21 +11857,71 @@
           [
             {
               "name": ":start",
-              "at": 48.200000047683716
+              "at": 51.90000009536743
             },
             {
               "name": ":done",
-              "at": 77.59999990463257
+              "at": 74.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 58.799999952316284
+              "at": 47.40000009536743
             },
             {
               "name": ":done",
-              "at": 81.90000009536743
+              "at": 70.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 49.59999990463257
+            },
+            {
+              "name": ":done",
+              "at": 73.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 48.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 69.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 53.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 74.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -9453,77 +11931,67 @@
             },
             {
               "name": ":done",
-              "at": 74.70000004768372
+              "at": 71.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.5
+              "at": 53.799999952316284
             },
             {
               "name": ":done",
-              "at": 85.70000004768372
+              "at": 78.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 55.5
+              "at": 52
             },
             {
               "name": ":done",
-              "at": 80.89999985694885
+              "at": 77.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.700000047683716
+              "at": 47.10000014305115
             },
             {
               "name": ":done",
-              "at": 77.59999990463257
+              "at": 71.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.40000009536743
+              "at": 47.40000009536743
             },
             {
               "name": ":done",
-              "at": 78.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 48.799999952316284
-            },
-            {
-              "name": ":done",
-              "at": 102.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 48.299999952316284
-            },
-            {
-              "name": ":done",
-              "at": 82.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 52.5
-            },
-            {
-              "name": ":done",
-              "at": 79.20000004768372
+              "at": 68.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9537,81 +12005,43 @@
           [
             {
               "name": ":start",
-              "at": 113.09999990463257
+              "at": 107.90000009536743
             },
             {
               "name": ":done",
-              "at": 1174.8999998569489
+              "at": 1159.1000001430511,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 120
+              "at": 115.5
             },
             {
               "name": ":done",
-              "at": 1188.7999999523163
+              "at": 1166.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.39999985694885
+              "at": 112.60000014305115
             },
             {
               "name": ":done",
-              "at": 1177.5999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 112.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 1187.0999999046326
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 121.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1288
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 121.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 1229
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 115.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 1175.4000000953674
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 120.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 1191.0999999046326
+              "at": 1230.1000001430511,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -9621,17 +12051,95 @@
             },
             {
               "name": ":done",
-              "at": 1181.0999999046326
+              "at": 1193.8999998569489,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 143
+              "at": 114
             },
             {
               "name": ":done",
-              "at": 1207.2000000476837
+              "at": 1191.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 120.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 1200.8000001907349,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 118.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1179.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 134.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 1209.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 116.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 1153.1999998092651,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 112.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 1175.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9645,101 +12153,141 @@
           [
             {
               "name": ":start",
-              "at": 117
+              "at": 116.10000014305115
             },
             {
               "name": ":done",
-              "at": 161.69999980926514
+              "at": 138.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 123.70000004768372
+              "at": 119.29999995231628
             },
             {
               "name": ":done",
-              "at": 165.5
+              "at": 145.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.59999990463257
+              "at": 114.60000014305115
             },
             {
               "name": ":done",
-              "at": 170.59999990463257
+              "at": 137.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 138.20000004768372
+              "at": 121.59999990463257
             },
             {
               "name": ":done",
-              "at": 173.29999995231628
+              "at": 146.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 126
+              "at": 125.39999985694885
             },
             {
               "name": ":done",
-              "at": 162.5
+              "at": 151.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 116.59999990463257
+              "at": 117.5
             },
             {
               "name": ":done",
-              "at": 155.89999985694885
+              "at": 140.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 116.39999985694885
+              "at": 111.20000004768372
             },
             {
               "name": ":done",
-              "at": 153.69999980926514
+              "at": 137.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.19999980926514
+              "at": 120.30000019073486
             },
             {
               "name": ":done",
-              "at": 153.79999995231628
+              "at": 146,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 122.89999985694885
+              "at": 113.20000004768372
             },
             {
               "name": ":done",
-              "at": 158.29999995231628
+              "at": 139.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.60000014305115
+              "at": 123.40000009536743
             },
             {
               "name": ":done",
-              "at": 158.10000014305115
+              "at": 145.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9753,101 +12301,141 @@
           [
             {
               "name": ":start",
-              "at": 114.59999990463257
+              "at": 118
             },
             {
               "name": ":done",
-              "at": 214.5
+              "at": 191,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.40000009536743
+              "at": 120.90000009536743
             },
             {
               "name": ":done",
-              "at": 217.60000014305115
+              "at": 195.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 116.59999990463257
+              "at": 130.40000009536743
             },
             {
               "name": ":done",
-              "at": 213.59999990463257
+              "at": 206.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 115.90000009536743
+              "at": 120.5
             },
             {
               "name": ":done",
-              "at": 215.60000014305115
+              "at": 193.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.20000004768372
+              "at": 123.40000009536743
             },
             {
               "name": ":done",
-              "at": 206.90000009536743
+              "at": 197.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.79999995231628
+              "at": 117.09999990463257
             },
             {
               "name": ":done",
-              "at": 212.69999980926514
+              "at": 193.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.29999995231628
+              "at": 120.5
             },
             {
               "name": ":done",
-              "at": 209.20000004768372
+              "at": 200.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 119.5
+              "at": 136.69999980926514
             },
             {
               "name": ":done",
-              "at": 196.79999995231628
+              "at": 212.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 134.70000004768372
+              "at": 116.5
             },
             {
               "name": ":done",
-              "at": 219.5
+              "at": 196.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 124.79999995231628
+              "at": 119.10000014305115
             },
             {
               "name": ":done",
-              "at": 217.70000004768372
+              "at": 194,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9861,51 +12449,99 @@
           [
             {
               "name": ":start",
-              "at": 124
+              "at": 115
             },
             {
               "name": ":done",
-              "at": 155.09999990463257
+              "at": 125.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 142.59999990463257
+              "at": 113.20000004768372
             },
             {
               "name": ":done",
-              "at": 172.79999995231628
+              "at": 124.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 119.5
+              "at": 120.40000009536743
             },
             {
               "name": ":done",
-              "at": 147.70000004768372
+              "at": 130.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 122.70000004768372
+              "at": 117.09999990463257
             },
             {
               "name": ":done",
-              "at": 147.70000004768372
+              "at": 126.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 122.09999990463257
+              "at": 116.39999985694885
             },
             {
               "name": ":done",
-              "at": 155.20000004768372
+              "at": 126.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 121.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 130.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 116.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 126.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -9915,47 +12551,39 @@
             },
             {
               "name": ":done",
-              "at": 143.20000004768372
+              "at": 121.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 131.79999995231628
+              "at": 115.89999985694885
             },
             {
               "name": ":done",
-              "at": 164.29999995231628
+              "at": 125.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 117.90000009536743
+              "at": 118.10000014305115
             },
             {
               "name": ":done",
-              "at": 150
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 116.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 142.70000004768372
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 122.5
-            },
-            {
-              "name": ":done",
-              "at": 153.70000004768372
+              "at": 127.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -9969,101 +12597,141 @@
           [
             {
               "name": ":start",
-              "at": 118.5
-            },
-            {
-              "name": ":done",
-              "at": 425.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 121.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 412.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 126.90000009536743
-            },
-            {
-              "name": ":done",
-              "at": 416.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 121.5
-            },
-            {
-              "name": ":done",
-              "at": 412.5
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 118.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 405.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 118.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 429.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 125.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 439.2999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
               "at": 118.09999990463257
             },
             {
               "name": ":done",
-              "at": 432
+              "at": 404.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 118.90000009536743
+              "at": 111.29999995231628
             },
             {
               "name": ":done",
-              "at": 406.40000009536743
+              "at": 386.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 109.89999985694885
+              "at": 113.20000004768372
             },
             {
               "name": ":done",
-              "at": 407.89999985694885
+              "at": 403.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 119.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 411.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 114.40000009536743
+            },
+            {
+              "name": ":done",
+              "at": 399.2999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 119.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 397.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 109.10000014305115
+            },
+            {
+              "name": ":done",
+              "at": 414.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 115.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 407.2000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 124.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 408.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 118.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 399.7999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -10077,101 +12745,141 @@
           [
             {
               "name": ":start",
-              "at": 120.19999980926514
+              "at": 110.39999985694885
             },
             {
               "name": ":done",
-              "at": 151.79999995231628
+              "at": 124.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 125.79999995231628
+              "at": 113.09999990463257
             },
             {
               "name": ":done",
-              "at": 163.39999985694885
+              "at": 126.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 122.20000004768372
+              "at": 111.69999980926514
             },
             {
               "name": ":done",
-              "at": 155.40000009536743
+              "at": 125.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 119.40000009536743
+              "at": 118.10000014305115
             },
             {
               "name": ":done",
-              "at": 153.79999995231628
+              "at": 131.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 121.59999990463257
+              "at": 115.59999990463257
             },
             {
               "name": ":done",
-              "at": 134.20000004768372
+              "at": 129.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 121.89999985694885
+              "at": 111.90000009536743
             },
             {
               "name": ":done",
-              "at": 152.20000004768372
+              "at": 127.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 127.10000014305115
+              "at": 114.40000009536743
             },
             {
               "name": ":done",
-              "at": 163.70000004768372
+              "at": 126.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 122
+              "at": 116.29999995231628
             },
             {
               "name": ":done",
-              "at": 160.79999995231628
+              "at": 130.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 120
+              "at": 118.10000014305115
             },
             {
               "name": ":done",
-              "at": 155.90000009536743
+              "at": 130.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 116.79999995231628
+              "at": 123
             },
             {
               "name": ":done",
-              "at": 148.40000009536743
+              "at": 138.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -10185,101 +12893,141 @@
           [
             {
               "name": ":start",
-              "at": 97.09999990463257
+              "at": 101.79999995231628
             },
             {
               "name": ":done",
-              "at": 1764.5999999046326
+              "at": 1798.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 96.79999995231628
+              "at": 94.70000004768372
             },
             {
               "name": ":done",
-              "at": 1927.1000001430511
+              "at": 1761.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 97.09999990463257
+              "at": 92.29999995231628
             },
             {
               "name": ":done",
-              "at": 1904.2999999523163
+              "at": 1728,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 90.70000004768372
+              "at": 92.39999985694885
             },
             {
               "name": ":done",
-              "at": 1864.9000000953674
+              "at": 1808.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 100.5
+              "at": 89.30000019073486
             },
             {
               "name": ":done",
-              "at": 1866.5999999046326
+              "at": 1792.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.59999990463257
+              "at": 87.40000009536743
             },
             {
               "name": ":done",
-              "at": 1965.4000000953674
+              "at": 1848.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 92.60000014305115
+              "at": 112.70000004768372
             },
             {
               "name": ":done",
-              "at": 1851
+              "at": 1819.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 93.29999995231628
+              "at": 89.09999990463257
             },
             {
               "name": ":done",
-              "at": 1874
+              "at": 1853.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.40000009536743
+              "at": 115.29999995231628
             },
             {
               "name": ":done",
-              "at": 1874.2999999523163
+              "at": 1828.0999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 100
+              "at": 89.70000004768372
             },
             {
               "name": ":done",
-              "at": 1818.8999998569489
+              "at": 1781.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -10293,101 +13041,141 @@
           [
             {
               "name": ":start",
-              "at": 96.29999995231628
+              "at": 90
             },
             {
               "name": ":done",
-              "at": 363.2000000476837
+              "at": 363.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 105.69999980926514
+              "at": 92.09999990463257
             },
             {
               "name": ":done",
-              "at": 364.09999990463257
+              "at": 376.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 89.20000004768372
+              "at": 89.80000019073486
             },
             {
               "name": ":done",
-              "at": 393.2000000476837
+              "at": 387.80000019073486,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.09999990463257
+              "at": 93
             },
             {
               "name": ":done",
-              "at": 376.89999985694885
+              "at": 330.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 92.20000004768372
+              "at": 91.20000004768372
             },
             {
               "name": ":done",
-              "at": 380.7000000476837
+              "at": 370.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.79999995231628
+              "at": 95.20000004768372
             },
             {
               "name": ":done",
-              "at": 394.7999999523163
+              "at": 399.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 94.39999985694885
+              "at": 90.29999995231628
             },
             {
               "name": ":done",
-              "at": 372.7999999523163
+              "at": 360.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.79999995231628
+              "at": 95.39999985694885
             },
             {
               "name": ":done",
-              "at": 357.7000000476837
+              "at": 384.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 103.09999990463257
+              "at": 91.40000009536743
             },
             {
               "name": ":done",
-              "at": 390.39999985694885
+              "at": 404.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 96.89999985694885
+              "at": 85.09999990463257
             },
             {
               "name": ":done",
-              "at": 385
+              "at": 363.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -10401,101 +13189,141 @@
           [
             {
               "name": ":start",
-              "at": 94.10000014305115
+              "at": 96
             },
             {
               "name": ":done",
-              "at": 230.10000014305115
+              "at": 224.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 96.5
+              "at": 87.70000004768372
             },
             {
               "name": ":done",
-              "at": 228.79999995231628
+              "at": 216.30000019073486,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 95.10000014305115
+              "at": 86.29999995231628
             },
             {
               "name": ":done",
-              "at": 227.40000009536743
+              "at": 212.70000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 93.79999995231628
+              "at": 91.39999985694885
             },
             {
               "name": ":done",
-              "at": 224
+              "at": 225.70000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.79999995231628
+              "at": 87.59999990463257
             },
             {
               "name": ":done",
-              "at": 223.5
+              "at": 221,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 90
+              "at": 94.40000009536743
             },
             {
               "name": ":done",
-              "at": 223.5
+              "at": 222,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 92.39999985694885
+              "at": 94.5
             },
             {
               "name": ":done",
-              "at": 226.89999985694885
+              "at": 239.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 94.29999995231628
+              "at": 96.29999995231628
             },
             {
               "name": ":done",
-              "at": 242.29999995231628
+              "at": 236.59999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 96.89999985694885
+              "at": 88.5
             },
             {
               "name": ":done",
-              "at": 239.09999990463257
+              "at": 215.90000009536743,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 91.29999995231628
+              "at": 90.40000009536743
             },
             {
               "name": ":done",
-              "at": 229.29999995231628
+              "at": 226.79999995231628,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -10511,36 +13339,40 @@
           [
             {
               "name": ":start",
-              "at": 65
+              "at": 62.10000014305115
             },
             {
               "name": "fps",
-              "at": 5175.799999952316,
-              "detail": 80.4
+              "at": 5162.299999952316,
+              "detail": 101.33847049144141
             },
             {
               "name": "fps",
-              "at": 10175.5,
-              "detail": 89.7
+              "at": 10164.100000143051,
+              "detail": 101
             },
             {
               "name": "fps",
-              "at": 15175.599999904633,
-              "detail": 86.8
+              "at": 15154.400000095367,
+              "detail": 109.2
             },
             {
               "name": "fps",
-              "at": 20177.89999985695,
-              "detail": 85.9
+              "at": 20164,
+              "detail": 110.00000000000004
             },
             {
               "name": "fps",
-              "at": 25195.799999952316,
-              "detail": 92.7
+              "at": 25152.60000014305,
+              "detail": 113.78888955666405
             },
             {
               "name": ":done",
-              "at": 25196.89999985695
+              "at": 25153.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -10555,101 +13387,141 @@
           [
             {
               "name": ":start",
-              "at": 53.89999985694885
+              "at": 44.200000047683716
             },
             {
               "name": ":done",
-              "at": 1072.5
+              "at": 681.5999999046326,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.10000014305115
+              "at": 54.40000009536743
             },
             {
               "name": ":done",
-              "at": 906.9000000953674
+              "at": 582.9000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.09999990463257
+              "at": 44.90000009536743
             },
             {
               "name": ":done",
-              "at": 880.7000000476837
+              "at": 579.4000000953674,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.799999952316284
+              "at": 52.5
             },
             {
               "name": ":done",
-              "at": 876.8999998569489
+              "at": 569,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 54
+              "at": 45
             },
             {
               "name": ":done",
-              "at": 912.6000001430511
+              "at": 568.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.799999952316284
+              "at": 46.59999990463257
             },
             {
               "name": ":done",
-              "at": 898.0999999046326
+              "at": 581,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.700000047683716
+              "at": 44.90000009536743
             },
             {
               "name": ":done",
-              "at": 894.5
+              "at": 557.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 59.40000009536743
+              "at": 45.799999952316284
             },
             {
               "name": ":done",
-              "at": 884.2999999523163
+              "at": 561.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.799999952316284
+              "at": 56.799999952316284
             },
             {
               "name": ":done",
-              "at": 883.2000000476837
+              "at": 586.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.799999952316284
+              "at": 46.200000047683716
             },
             {
               "name": ":done",
-              "at": 883.7999999523163
+              "at": 584.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -10663,81 +13535,113 @@
           [
             {
               "name": ":start",
-              "at": 53.60000014305115
+              "at": 42.10000014305115
             },
             {
               "name": ":done",
-              "at": 80.30000019073486
+              "at": 57.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.700000047683716
+              "at": 46.10000014305115
             },
             {
               "name": ":done",
-              "at": 82.60000014305115
+              "at": 60.30000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.10000014305115
+              "at": 49
             },
             {
               "name": ":done",
-              "at": 80.20000004768372
+              "at": 62.799999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.09999990463257
+              "at": 45.40000009536743
             },
             {
               "name": ":done",
-              "at": 81.09999990463257
+              "at": 60,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.5
+              "at": 45.40000009536743
             },
             {
               "name": ":done",
-              "at": 86.79999995231628
+              "at": 58,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 49.299999952316284
+              "at": 46.09999990463257
             },
             {
               "name": ":done",
-              "at": 76
+              "at": 60.799999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.30000019073486
+              "at": 45.700000047683716
             },
             {
               "name": ":done",
-              "at": 85.40000009536743
+              "at": 60.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51
+              "at": 44.19999980926514
             },
             {
               "name": ":done",
-              "at": 81.5
+              "at": 57.69999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -10747,17 +13651,25 @@
             },
             {
               "name": ":done",
-              "at": 81.70000004768372
+              "at": 65.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.5
+              "at": 44.299999952316284
             },
             {
               "name": ":done",
-              "at": 78.69999980926514
+              "at": 57.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -10771,101 +13683,141 @@
           [
             {
               "name": ":start",
-              "at": 49.39999985694885
+              "at": 47.299999952316284
             },
             {
               "name": ":done",
-              "at": 60
+              "at": 53.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 54.700000047683716
+              "at": 45.39999985694885
             },
             {
               "name": ":done",
-              "at": 65.79999995231628
+              "at": 72.39999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 56
+              "at": 43.5
             },
             {
               "name": ":done",
-              "at": 73.69999980926514
+              "at": 48.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.09999990463257
+              "at": 47
             },
             {
               "name": ":done",
-              "at": 60.5
+              "at": 52.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 54.700000047683716
+              "at": 44.299999952316284
             },
             {
               "name": ":done",
-              "at": 68.70000004768372
+              "at": 51,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 56
+              "at": 45.299999952316284
             },
             {
               "name": ":done",
-              "at": 74.40000009536743
+              "at": 51.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.39999985694885
+              "at": 43.40000009536743
             },
             {
               "name": ":done",
-              "at": 61.700000047683716
+              "at": 48.700000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.09999990463257
+              "at": 47.89999985694885
             },
             {
               "name": ":done",
-              "at": 69.40000009536743
+              "at": 53.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.299999952316284
+              "at": 44.59999990463257
             },
             {
               "name": ":done",
-              "at": 61.799999952316284
+              "at": 50.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.09999990463257
+              "at": 48
             },
             {
               "name": ":done",
-              "at": 62.200000047683716
+              "at": 53.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -10879,101 +13831,141 @@
           [
             {
               "name": ":start",
-              "at": 52.89999985694885
+              "at": 48
             },
             {
               "name": ":done",
-              "at": 540.6999998092651
+              "at": 335.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 54.200000047683716
+              "at": 46.10000014305115
             },
             {
               "name": ":done",
-              "at": 544.6000001430511
+              "at": 347.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 63.09999990463257
+              "at": 47.60000014305115
             },
             {
               "name": ":done",
-              "at": 567.8999998569489
+              "at": 324.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.299999952316284
+              "at": 45.700000047683716
             },
             {
               "name": ":done",
-              "at": 536.9000000953674
+              "at": 342.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 47.59999990463257
+              "at": 49.5
             },
             {
               "name": ":done",
-              "at": 530.3999998569489
+              "at": 348.7000000476837,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.90000009536743
+              "at": 46.700000047683716
             },
             {
               "name": ":done",
-              "at": 540.2000000476837
+              "at": 342.80000019073486,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 56.40000009536743
+              "at": 46.700000047683716
             },
             {
               "name": ":done",
-              "at": 583.2999999523163
+              "at": 334.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.60000014305115
+              "at": 45.5
             },
             {
               "name": ":done",
-              "at": 566.7000000476837
+              "at": 333.2999999523163,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.700000047683716
+              "at": 47.5
             },
             {
               "name": ":done",
-              "at": 554.7999999523163
+              "at": 322.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 53.799999952316284
+              "at": 55.39999985694885
             },
             {
               "name": ":done",
-              "at": 543.7000000476837
+              "at": 343.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -10987,101 +13979,141 @@
           [
             {
               "name": ":start",
-              "at": 48.799999952316284
+              "at": 42.40000009536743
             },
             {
               "name": ":done",
-              "at": 65.79999995231628
+              "at": 54.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.89999985694885
+              "at": 46.40000009536743
             },
             {
               "name": ":done",
-              "at": 71.5
+              "at": 58.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 55.700000047683716
+              "at": 42.5
             },
             {
               "name": ":done",
-              "at": 71.40000009536743
+              "at": 54.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 57.5
+              "at": 43.59999990463257
             },
             {
               "name": ":done",
-              "at": 70.40000009536743
+              "at": 56.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.700000047683716
+              "at": 44.700000047683716
             },
             {
               "name": ":done",
-              "at": 67.59999990463257
+              "at": 58.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 51.700000047683716
+              "at": 46.59999990463257
             },
             {
               "name": ":done",
-              "at": 67.29999995231628
+              "at": 59.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.09999990463257
+              "at": 41.799999952316284
             },
             {
               "name": ":done",
-              "at": 66.79999995231628
+              "at": 53.200000047683716,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 60
+              "at": 47.09999990463257
             },
             {
               "name": ":done",
-              "at": 72.09999990463257
+              "at": 58.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 50.799999952316284
+              "at": 52.700000047683716
             },
             {
               "name": ":done",
-              "at": 68
+              "at": 63.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 52.40000009536743
+              "at": 49.09999990463257
             },
             {
               "name": ":done",
-              "at": 99.40000009536743
+              "at": 63.299999952316284,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11095,101 +14127,141 @@
           [
             {
               "name": ":start",
-              "at": 78.90000009536743
+              "at": 77.40000009536743
             },
             {
               "name": ":done",
-              "at": 734.2000000476837
+              "at": 207.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74.30000019073486
+              "at": 77.79999995231628
             },
             {
               "name": ":done",
-              "at": 717.6000001430511
+              "at": 195,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 75.5
+              "at": 76.29999995231628
             },
             {
               "name": ":done",
-              "at": 742
+              "at": 195.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 73.79999995231628
+              "at": 77.90000009536743
             },
             {
               "name": ":done",
-              "at": 733.7000000476837
+              "at": 197.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 97.09999990463257
+              "at": 71.40000009536743
             },
             {
               "name": ":done",
-              "at": 743.3999998569489
+              "at": 186.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.79999995231628
+              "at": 78.19999980926514
             },
             {
               "name": ":done",
-              "at": 734.7000000476837
+              "at": 193.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76
+              "at": 73.29999995231628
             },
             {
               "name": ":done",
-              "at": 745
+              "at": 193.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.40000009536743
+              "at": 79.59999990463257
             },
             {
               "name": ":done",
-              "at": 727.1000001430511
+              "at": 196.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.10000014305115
+              "at": 78.5
             },
             {
               "name": ":done",
-              "at": 723.1000001430511
+              "at": 201.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74
+              "at": 78.70000004768372
             },
             {
               "name": ":done",
-              "at": 728
+              "at": 196.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11203,11 +14275,113 @@
           [
             {
               "name": ":start",
-              "at": 75.5
+              "at": 74.80000019073486
             },
             {
               "name": ":done",
-              "at": 110.20000004768372
+              "at": 94,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 96.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 75.80000019073486
+            },
+            {
+              "name": ":done",
+              "at": 97.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.5
+            },
+            {
+              "name": ":done",
+              "at": 104.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 73.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 93.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 103.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 74
+            },
+            {
+              "name": ":done",
+              "at": 93.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 80.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 101.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -11217,87 +14391,25 @@
             },
             {
               "name": ":done",
-              "at": 113.29999995231628
+              "at": 96.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 72.70000004768372
+              "at": 80.39999985694885
             },
             {
               "name": ":done",
-              "at": 116.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 117.89999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 112.29999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.5
-            },
-            {
-              "name": ":done",
-              "at": 96.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 78.89999985694885
-            },
-            {
-              "name": ":done",
-              "at": 115.59999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 114
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 111.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 81.70000004768372
-            },
-            {
-              "name": ":done",
-              "at": 120.10000014305115
+              "at": 102,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11311,101 +14423,141 @@
           [
             {
               "name": ":start",
-              "at": 86
+              "at": 86.20000004768372
             },
             {
               "name": ":done",
-              "at": 169.70000004768372
+              "at": 105,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 98.40000009536743
+              "at": 87.79999995231628
             },
             {
               "name": ":done",
-              "at": 161.09999990463257
+              "at": 108.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 73.59999990463257
+              "at": 79.40000009536743
             },
             {
               "name": ":done",
-              "at": 164.20000004768372
+              "at": 99.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.09999990463257
+              "at": 79.59999990463257
             },
             {
               "name": ":done",
-              "at": 166.90000009536743
+              "at": 98.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 77
+              "at": 80.60000014305115
             },
             {
               "name": ":done",
-              "at": 164.80000019073486
+              "at": 98.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 100.90000009536743
+              "at": 79.5
             },
             {
               "name": ":done",
-              "at": 189.20000004768372
+              "at": 101.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74.20000004768372
+              "at": 87.60000014305115
             },
             {
               "name": ":done",
-              "at": 163.20000004768372
+              "at": 107.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.29999995231628
+              "at": 79.89999985694885
             },
             {
               "name": ":done",
-              "at": 170.09999990463257
+              "at": 98.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.69999980926514
+              "at": 77.09999990463257
             },
             {
               "name": ":done",
-              "at": 165.39999985694885
+              "at": 96.90000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74.09999990463257
+              "at": 82.10000014305115
             },
             {
               "name": ":done",
-              "at": 161.89999985694885
+              "at": 101.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11419,51 +14571,71 @@
           [
             {
               "name": ":start",
-              "at": 83.20000004768372
+              "at": 78.70000004768372
             },
             {
               "name": ":done",
-              "at": 109.59999990463257
+              "at": 86.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74.10000014305115
+              "at": 77.79999995231628
             },
             {
               "name": ":done",
-              "at": 108.20000004768372
+              "at": 86.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 114.60000014305115
+              "at": 87.90000009536743
             },
             {
               "name": ":done",
-              "at": 142.60000014305115
+              "at": 95.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 80.59999990463257
+              "at": 79.29999995231628
             },
             {
               "name": ":done",
-              "at": 112.79999995231628
+              "at": 87.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 75.5
+              "at": 75.20000004768372
             },
             {
               "name": ":done",
-              "at": 109.10000014305115
+              "at": 82.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -11473,47 +14645,67 @@
             },
             {
               "name": ":done",
-              "at": 109.89999985694885
+              "at": 89,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.20000004768372
+              "at": 81.40000009536743
             },
             {
               "name": ":done",
-              "at": 108.90000009536743
+              "at": 90.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 73
+              "at": 87.89999985694885
             },
             {
               "name": ":done",
-              "at": 104.79999995231628
+              "at": 93.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 74.5
+              "at": 80.29999995231628
             },
             {
               "name": ":done",
-              "at": 92.29999995231628
+              "at": 88,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 75.89999985694885
+              "at": 100.39999985694885
             },
             {
               "name": ":done",
-              "at": 112.19999980926514
+              "at": 107.19999980926514,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11527,21 +14719,113 @@
           [
             {
               "name": ":start",
-              "at": 79.19999980926514
+              "at": 78.20000004768372
             },
             {
               "name": ":done",
-              "at": 279.2999999523163
+              "at": 125.60000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 73.70000004768372
+              "at": 80.79999995231628
             },
             {
               "name": ":done",
-              "at": 298.09999990463257
+              "at": 128.10000014305115,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 84.39999985694885
+            },
+            {
+              "name": ":done",
+              "at": 128.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 130,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 83.70000004768372
+            },
+            {
+              "name": ":done",
+              "at": 132.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 120.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.5
+            },
+            {
+              "name": ":done",
+              "at": 122.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 76.09999990463257
+            },
+            {
+              "name": ":done",
+              "at": 124.59999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
@@ -11551,77 +14835,25 @@
             },
             {
               "name": ":done",
-              "at": 299.2999999523163
+              "at": 124.40000009536743,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 95.59999990463257
+              "at": 76.89999985694885
             },
             {
               "name": ":done",
-              "at": 321.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.79999995231628
-            },
-            {
-              "name": ":done",
-              "at": 301
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 82.5
-            },
-            {
-              "name": ":done",
-              "at": 310.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 77.09999990463257
-            },
-            {
-              "name": ":done",
-              "at": 269.7999999523163
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 80
-            },
-            {
-              "name": ":done",
-              "at": 304.90000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 77.10000014305115
-            },
-            {
-              "name": ":done",
-              "at": 304.40000009536743
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 80.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 306.69999980926514
+              "at": 125.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11635,101 +14867,141 @@
           [
             {
               "name": ":start",
+              "at": 75.79999995231628
+            },
+            {
+              "name": ":done",
+              "at": 85.79999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 82.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 93.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.29999995231628
+            },
+            {
+              "name": ":done",
+              "at": 88.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.30000019073486
+            },
+            {
+              "name": ":done",
+              "at": 88.5,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 75.89999985694885
+            },
+            {
+              "name": ":done",
+              "at": 85.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 78.90000009536743
+            },
+            {
+              "name": ":done",
+              "at": 89.20000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 77.60000014305115
+            },
+            {
+              "name": ":done",
+              "at": 88.70000004768372,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
+              "at": 96.20000004768372
+            },
+            {
+              "name": ":done",
+              "at": 107.09999990463257,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
+            }
+          ],
+          [
+            {
+              "name": ":start",
               "at": 77.59999990463257
             },
             {
               "name": ":done",
-              "at": 121.09999990463257
+              "at": 87.89999985694885,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76
+              "at": 77
             },
             {
               "name": ":done",
-              "at": 112.79999995231628
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 84.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 98.39999985694885
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 80.29999995231628
-            },
-            {
-              "name": ":done",
-              "at": 141.10000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.80000019073486
-            },
-            {
-              "name": ":done",
-              "at": 108.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 77.20000004768372
-            },
-            {
-              "name": ":done",
-              "at": 112.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 76.60000014305115
-            },
-            {
-              "name": ":done",
-              "at": 109.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 74.5
-            },
-            {
-              "name": ":done",
-              "at": 107.60000014305115
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 75.39999985694885
-            },
-            {
-              "name": ":done",
-              "at": 112.09999990463257
-            }
-          ],
-          [
-            {
-              "name": ":start",
-              "at": 79.59999990463257
-            },
-            {
-              "name": ":done",
-              "at": 112.29999995231628
+              "at": 88.29999995231628,
+              "detail": {
+                "checks": 2,
+                "via": "mutation"
+              }
             }
           ]
         ],
@@ -11743,101 +15015,141 @@
           [
             {
               "name": ":start",
-              "at": 83.20000004768372
+              "at": 84.20000004768372
             },
             {
               "name": ":done",
-              "at": 3513.2000000476837
+              "at": 1340.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 80.20000004768372
+              "at": 87.79999995231628
             },
             {
               "name": ":done",
-              "at": 3453
+              "at": 1267.3999998569489,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79.40000009536743
+              "at": 86.5
             },
             {
               "name": ":done",
-              "at": 3519.9000000953674
+              "at": 1498.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 81.29999995231628
+              "at": 82.20000004768372
             },
             {
               "name": ":done",
-              "at": 3589.2999999523163
+              "at": 1506.8000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.90000009536743
+              "at": 113.70000004768372
             },
             {
               "name": ":done",
-              "at": 3525.2999999523163
+              "at": 1489.3000001907349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 80.60000014305115
+              "at": 84.79999995231628
             },
             {
               "name": ":done",
-              "at": 3459.5
+              "at": 1632.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79.79999995231628
+              "at": 91.29999995231628
             },
             {
               "name": ":done",
-              "at": 3558.9000000953674
+              "at": 1461.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 83.89999985694885
+              "at": 86
             },
             {
               "name": ":done",
-              "at": 3624.7000000476837
+              "at": 680.2999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76
+              "at": 75
             },
             {
               "name": ":done",
-              "at": 3484.2000000476837
+              "at": 863.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 86.39999985694885
+              "at": 72.60000014305115
             },
             {
               "name": ":done",
-              "at": 3654.899999856949
+              "at": 837.1000001430511,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -11851,101 +15163,141 @@
           [
             {
               "name": ":start",
-              "at": 75
+              "at": 71.29999995231628
             },
             {
               "name": ":done",
-              "at": 440.40000009536743
+              "at": 367.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 85
+              "at": 74
             },
             {
               "name": ":done",
-              "at": 450.10000014305115
+              "at": 332.7999999523163,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.70000004768372
+              "at": 74
             },
             {
               "name": ":done",
-              "at": 437.5
+              "at": 339.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79.09999990463257
+              "at": 74.80000019073486
             },
             {
               "name": ":done",
-              "at": 441.09999990463257
+              "at": 357.2000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.70000004768372
+              "at": 73.59999990463257
             },
             {
               "name": ":done",
-              "at": 440.2000000476837
+              "at": 382.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 86.5
+              "at": 73.70000004768372
             },
             {
               "name": ":done",
-              "at": 441
+              "at": 354.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 77.40000009536743
+              "at": 78
             },
             {
               "name": ":done",
-              "at": 430
+              "at": 352.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 80.29999995231628
+              "at": 75.10000014305115
             },
             {
               "name": ":done",
-              "at": 447.5
+              "at": 349,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 97.29999995231628
+              "at": 76.09999990463257
             },
             {
               "name": ":done",
-              "at": 464.09999990463257
+              "at": 354.09999990463257,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79
+              "at": 72.79999995231628
             },
             {
               "name": ":done",
-              "at": 436.10000014305115
+              "at": 328.7000000476837,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -11959,101 +15311,141 @@
           [
             {
               "name": ":start",
-              "at": 76.19999980926514
+              "at": 96.60000014305115
             },
             {
               "name": ":done",
-              "at": 93.89999985694885
+              "at": 279.10000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 77.79999995231628
+              "at": 73.59999990463257
             },
             {
               "name": ":done",
-              "at": 96.40000009536743
+              "at": 266.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 76.90000009536743
+              "at": 80.59999990463257
             },
             {
               "name": ":done",
-              "at": 95.09999990463257
+              "at": 242.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 81
+              "at": 91.29999995231628
             },
             {
               "name": ":done",
-              "at": 102.19999980926514
+              "at": 259.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.89999985694885
+              "at": 73
             },
             {
               "name": ":done",
-              "at": 96.89999985694885
+              "at": 246.80000019073486,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 79.90000009536743
+              "at": 72.79999995231628
             },
             {
               "name": ":done",
-              "at": 123.20000004768372
+              "at": 231.39999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 80
+              "at": 74.59999990463257
             },
             {
               "name": ":done",
-              "at": 97.30000019073486
+              "at": 250.5,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.40000009536743
+              "at": 74.20000004768372
             },
             {
               "name": ":done",
-              "at": 101.20000004768372
+              "at": 235.60000014305115,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 78.10000014305115
+              "at": 73.09999990463257
             },
             {
               "name": ":done",
-              "at": 97.90000009536743
+              "at": 229.70000004768372,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ],
           [
             {
               "name": ":start",
-              "at": 77.20000004768372
+              "at": 75.79999995231628
             },
             {
               "name": ":done",
-              "at": 94.20000004768372
+              "at": 239.89999985694885,
+              "detail": {
+                "checks": 1,
+                "via": "immediate"
+              }
             }
           ]
         ],
@@ -12197,8 +15589,8 @@
     }
   ],
   "timing": {
-    "buildMs": 59874,
-    "benchmarkMs": 942043,
-    "totalMs": 1001917
+    "buildMs": 52533,
+    "benchmarkMs": 873558,
+    "totalMs": 926091
   }
 }

--- a/results/public/results/2026-07-29T00:58:09.174Z.json
+++ b/results/public/results/2026-07-29T00:58:09.174Z.json
@@ -10,6 +10,11 @@
     "BENCH_NAME": "all",
     "TIMEOUT": 60000
   },
+  "notes": {
+    "vue": {
+      "variant": "Vapor"
+    }
+  },
   "environment": {
     "machine": {
       "os": {

--- a/results/types/index.d.ts
+++ b/results/types/index.d.ts
@@ -1,3 +1,10 @@
 declare module "virtual:result-sets" {
-  export const results: string[];
+  /**
+   * The official benchmark runs, from public/results, newest-first.
+   */
+  export const runs: string[];
+  /**
+   * Experimental runs, from public/experiments, newest-first.
+   */
+  export const experiments: string[];
 }

--- a/results/vite.config.mjs
+++ b/results/vite.config.mjs
@@ -8,10 +8,28 @@ const RESULT_SETS = "virtual:result-sets";
 const RESOLVED_RESULT_SETS = "\0" + RESULT_SETS;
 
 /**
- * Like vite-plugin-virtual, but re-reads the directory whenever
- * files change in public/results -- otherwise the dev server keeps
- * serving the file list from when it started, and newly added
+ * The names of every result file in a directory, newest-first. Missing
+ * directories read as empty -- experiments are optional.
+ */
+function namesIn(dir) {
+  if (!fsSync.existsSync(dir)) return [];
+
+  return fsSync
+    .readdirSync(dir)
+    .filter((x) => x.endsWith(".json"))
+    .map((x) => x.replace(/\.json$/, ""))
+    .sort()
+    .reverse();
+}
+
+/**
+ * Like vite-plugin-virtual, but re-reads the directories whenever files
+ * change in public/results or public/experiments -- otherwise the dev
+ * server keeps serving the file list from when it started, and newly added
  * result files never show up (until a server restart).
+ *
+ * Result sets come in two categories: `runs` (the official runs in
+ * public/results) and `experiments` (public/experiments).
  */
 function resultSets() {
   return {
@@ -22,19 +40,19 @@ function resultSets() {
     load(id) {
       if (id !== RESOLVED_RESULT_SETS) return;
 
-      let sets = fsSync.readdirSync("./public/results");
-      let dates = sets
-        .map((x) => x.replace(".json", ""))
-        .sort()
-        .reverse()
-        .map((x) => `"${x}"`)
-        .join(", ");
+      const runs = namesIn("./public/results");
+      const experiments = namesIn("./public/experiments");
 
-      return `export const results = [${dates}];`;
+      return (
+        `export const runs = ${JSON.stringify(runs)};\n` +
+        `export const experiments = ${JSON.stringify(experiments)};`
+      );
     },
     configureServer(server) {
       const invalidate = (path) => {
-        if (!path.includes("public/results")) return;
+        if (!path.includes("public/results") && !path.includes("public/experiments")) {
+          return;
+        }
 
         const mod = server.moduleGraph.getModuleById(RESOLVED_RESULT_SETS);
 

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -7,7 +7,12 @@ import * as clack from '@clack/prompts';
 import * as args from './arg.ts';
 import { yyyymmdd } from './environment.ts';
 import { frameworks } from './repo.ts';
-import { info, saveBenchmarkInfo, saveVersionOverrides } from './results.ts';
+import {
+  info,
+  saveBenchmarkInfo,
+  saveNotes,
+  saveVersionOverrides,
+} from './results.ts';
 
 export interface BenchmarkInfo {
   /**
@@ -322,6 +327,7 @@ export async function getBenchInfo() {
   );
 
   await saveVersionOverrides(args.VERSION_OVERRIDES, filePath);
+  await saveNotes(selectedFrameworks, filePath);
 
   return {
     apps,

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -124,6 +124,32 @@ async function readJSON(filePath: string) {
   return json;
 }
 
+/**
+ * Per-framework notes, collected from `frameworks/<framework>/notes.json`
+ * when present, keyed by framework name. Lets a run carry small labels the
+ * results app shows -- e.g. Vue's `{ "variant": "Vapor" }`. Merged in, so
+ * appending to an existing file keeps notes already written to it.
+ */
+export async function saveNotes(frameworks: string[], filePath: string) {
+  const notes: Record<string, unknown> = {};
+
+  for (const framework of frameworks) {
+    const notePath = join('frameworks', framework, 'notes.json');
+
+    if (!existsSync(notePath)) continue;
+
+    notes[framework] = await readJSON(notePath);
+  }
+
+  if (Object.keys(notes).length === 0) return;
+
+  const file = await read(filePath);
+
+  file.notes = { ...file.notes, ...notes };
+
+  await write(file, filePath);
+}
+
 async function getVersion(framework: string, bench: BenchmarkInfo) {
   const dir = join('frameworks', framework, bench.app);
   const manifestPath = join(dir, 'package.json');


### PR DESCRIPTION
Also adds the experimental set from https://github.com/NullVoxPopuli/rere-benchmark/pull/68, but post solid, vue, and react compiler PRs