### PR TITLE
Runner: --include-prs records the PRs since the previous result set

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ window you've covered up.
 | `--headless` | off | headless caps at 60fps, so the frame-rate bench means less |
 | `--timeout` | `60000` | ms a single sample may take before the run fails |
 | `--skip-build` | off | re-use an existing build |
+| `--include-prs` | off | record the PRs that landed since the previous result set in the run's notes (from git history; shown in the results app) |
 
 ### Query params
 

--- a/results/app/components/env.gts
+++ b/results/app/components/env.gts
@@ -2,6 +2,7 @@ import { formatDuration, msOfFrameAt, throttleLabel } from "#utils";
 
 import type { TOC } from "@ember/component/template-only";
 import type { ResultSet } from "#types";
+import type { DisplayPr } from "#utils";
 
 function first8(str: string) {
   return str.slice(0, 8);
@@ -71,6 +72,22 @@ export const Info = <template>
         </li>
       {{/if}}
     </ul>
+
+    {{#if @prs.length}}
+      <details class="pr-notes">
+        <summary>PRs since the previous result set ({{@prs.length}})</summary>
+        <ul>
+          {{#each @prs as |pr|}}
+            <li>
+              <a target="_blank" rel="noopener noreferrer" href={{pr.url}}>
+                {{pr.label}}
+              </a>
+              {{#if pr.title}}{{pr.title}}{{/if}}
+            </li>
+          {{/each}}
+        </ul>
+      </details>
+    {{/if}}
   </div>
 </template> satisfies TOC<{
   date: string;
@@ -78,4 +95,5 @@ export const Info = <template>
   env: ResultSet["environment"];
   cpuThrottle: number | undefined;
   timing: ResultSet["timing"];
+  prs: DisplayPr[];
 }>;

--- a/results/app/templates/results.gts
+++ b/results/app/templates/results.gts
@@ -1,6 +1,7 @@
 import { LinkTo } from "@ember/routing";
 
 import { Info } from "#components/env.gts";
+import { prsOf } from "#utils";
 
 import type { TOC } from "@ember/component/template-only";
 import type { Model } from "#routes/results.ts";
@@ -20,6 +21,7 @@ export default <template>
     @env={{@model.data.environment}}
     @cpuThrottle={{@model.data.args.CPU_THROTTLE}}
     @timing={{@model.data.timing}}
+    @prs={{prsOf @model.data}}
   />
 
   <div class="all-results">

--- a/results/app/types.ts
+++ b/results/app/types.ts
@@ -41,6 +41,20 @@ export interface VersionOverride {
 }
 
 /**
+ * A PR recorded in a result set's notes. The runner writes these
+ * (`--include-prs`) from git history between the previous result set and
+ * the run; hand-added entries may also be plain URL strings.
+ */
+export interface PullRequestNote {
+  url: string;
+  /**
+   * The PR title, from the merge (or squash) commit. Absent on
+   * hand-added entries.
+   */
+  title?: string;
+}
+
+/**
  * Small labels a run records about a framework, collected by the runner
  * from `frameworks/<framework>/notes.json`.
  */
@@ -107,8 +121,13 @@ export interface ResultSet {
    * Optional per-framework notes, keyed by framework name. Collected by the
    * runner from `frameworks/<framework>/notes.json`, e.g.
    * `{ vue: { variant: "Vapor" } }`.
+   *
+   * `prs` sits alongside the framework keys: the PRs that landed between
+   * the previous result set and this run (see {@link PullRequestNote}).
    */
-  notes?: Record<string, FrameworkNotes>;
+  notes?: {
+    prs?: Array<string | PullRequestNote>;
+  } & Record<string, FrameworkNotes>;
   environment: {
     machine: {
       os: {

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -56,6 +56,32 @@ export function variantOf(file: ResultSet, framework: string) {
   return file.notes?.[framework]?.variant;
 }
 
+export interface DisplayPr {
+  url: string;
+  title?: string;
+  /**
+   * `#<number>` when the URL has one, the URL itself otherwise.
+   */
+  label: string;
+}
+
+/**
+ * The PRs a run recorded (the ones that landed between the previous
+ * result set and the run), normalized for display: the runner records
+ * `{ url, title }`, hand-added entries are plain URL strings.
+ */
+export function prsOf(file: ResultSet): DisplayPr[] {
+  const prs = file.notes?.prs ?? [];
+
+  return prs.map((pr) => {
+    const url = typeof pr === "string" ? pr : pr.url;
+    const title = typeof pr === "string" ? undefined : pr.title;
+    const number = url.match(/\/pull\/(\d+)/)?.[1];
+
+    return { url, title, label: number ? `#${number}` : url };
+  });
+}
+
 /**
  * How one framework did at one benchmark, or undefined when that run
  * doesn't have the pair.

--- a/src/runner/arg.ts
+++ b/src/runner/arg.ts
@@ -19,6 +19,7 @@ export const FRAMEWORK = str('--framework');
 export const BENCH_NAME = str('--bench');
 export const SKIP_BUILD = bool('--skip-build');
 export const TIMEOUT = int('--timeout', 60_000);
+export const INCLUDE_PRS = bool('--include-prs');
 export const VERSION_OVERRIDES = versionOverrides();
 
 function col1(name: string) {
@@ -56,6 +57,11 @@ console.log(
     row(col1('--timeout'), col2(TIMEOUT), col3('ms a single sample may take')),
     row(col1('--framework'), col2(FRAMEWORK), col3(`or '${ALL}'`)),
     row(col1('--bench'), col2(BENCH_NAME), col3(`or '${ALL}'`)),
+    row(
+      col1('--include-prs'),
+      col2(INCLUDE_PRS),
+      col3('record PRs merged since the previous result set'),
+    ),
     ...Object.entries(VERSION_OVERRIDES).map(([framework, override]) =>
       row(
         col1(`--${framework}`),

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -6,13 +6,17 @@ import * as clack from '@clack/prompts';
 
 import * as args from './arg.ts';
 import { yyyymmdd } from './environment.ts';
+import { prsSinceLastResultSet } from './prs.ts';
 import { frameworks } from './repo.ts';
 import {
   info,
   saveBenchmarkInfo,
   saveNotes,
+  savePrNotes,
   saveVersionOverrides,
 } from './results.ts';
+
+import type { PullRequestNote } from '../../results/app/types.ts';
 
 export interface BenchmarkInfo {
   /**
@@ -299,6 +303,29 @@ export async function getBenchInfo() {
   const selectedBenches = await getBenches();
   const filePath = await getFilePath();
 
+  // resolved before the confirm below, so what will be recorded is part
+  // of the "does this look correct?" review
+  let prNotes: PullRequestNote[] = [];
+
+  if (args.INCLUDE_PRS) {
+    const found = await prsSinceLastResultSet(filePath);
+
+    if (found && found.prs.length > 0) {
+      prNotes = found.prs;
+
+      clack.log.info(
+        `PRs since the previous result set (${found.since}):\n` +
+          found.prs
+            .map((pr) => `  ${pr.url}${pr.title ? ` — ${pr.title}` : ''}`)
+            .join('\n'),
+      );
+    } else {
+      clack.log.warn(
+        `--include-prs: no PRs found since the previous result set`,
+      );
+    }
+  }
+
   console.info(inspect(info, { showHidden: false, depth: null, colors: true }));
   console.log(`
     Results will be written to ${filePath}
@@ -328,6 +355,7 @@ export async function getBenchInfo() {
 
   await saveVersionOverrides(args.VERSION_OVERRIDES, filePath);
   await saveNotes(selectedFrameworks, filePath);
+  await savePrNotes(prNotes, filePath);
 
   return {
     apps,

--- a/src/runner/prs.ts
+++ b/src/runner/prs.ts
@@ -1,0 +1,100 @@
+import { readdir } from 'node:fs/promises';
+import { basename } from 'node:path';
+
+import { $ } from 'execa';
+
+import type { PullRequestNote } from '../../results/app/types.ts';
+
+const RESULTS_DIR = './results/public/results';
+
+/**
+ * Same base the results app links shas to.
+ */
+const REPO_URL = 'https://github.com/NullVoxPopuli/rere-benchmark';
+
+/**
+ * When the most recent result set (other than the one being written) was
+ * recorded. Result files are named with the run's ISO timestamp, so the
+ * directory listing is the history -- no need to open the files.
+ */
+async function previousResultSetDate(currentFilePath: string) {
+  const files = await readdir(RESULTS_DIR);
+  const current = basename(currentFilePath);
+
+  const dates = files
+    .filter((file) => file.endsWith('.json') && file !== current)
+    .map((file) => file.replace(/\.json$/, ''))
+    .filter((iso) => !Number.isNaN(Date.parse(iso)))
+    .sort();
+
+  return dates.at(-1);
+}
+
+/**
+ * The PRs that landed between the previous result set and now, from git
+ * history alone (no GitHub API):
+ *
+ * - a merge commit's subject is `Merge pull request #N from ...` and the
+ *   first line of its body is the PR title
+ * - a squash-merge's subject is `The PR title (#N)`
+ *
+ * Newest first, like `git log`. Deduplicated by number, so a PR that
+ * appears both ways (or twice via --since's commit-date filter) is
+ * recorded once.
+ */
+export async function prsSinceLastResultSet(currentFilePath: string) {
+  const since = await previousResultSetDate(currentFilePath);
+
+  if (!since) return;
+
+  // NUL between subject and body, RS between commits: bodies span lines
+  const format = '%s%x00%b%x1e';
+  const { stdout } = await $`git log --since=${since} --format=${format}`;
+
+  const prs: PullRequestNote[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of stdout.split('\x1e')) {
+    const [subject = '', body = ''] = entry.trim().split('\0');
+
+    const pr = fromMergeCommit(subject, body) ?? fromSquashCommit(subject);
+
+    if (!pr) continue;
+    if (seen.has(pr.url)) continue;
+
+    seen.add(pr.url);
+    prs.push(pr);
+  }
+
+  return { since, prs };
+}
+
+function fromMergeCommit(
+  subject: string,
+  body: string,
+): PullRequestNote | undefined {
+  const merge = subject.match(/^Merge pull request #(?<number>\d+) from /);
+
+  if (!merge?.groups) return;
+
+  const title = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  return {
+    url: `${REPO_URL}/pull/${merge.groups['number']}`,
+    ...(title ? { title } : {}),
+  };
+}
+
+function fromSquashCommit(subject: string): PullRequestNote | undefined {
+  const squash = subject.match(/^(?<title>.+) \(#(?<number>\d+)\)$/);
+
+  if (!squash?.groups) return;
+
+  return {
+    url: `${REPO_URL}/pull/${squash.groups['number']}`,
+    title: squash.groups['title'],
+  };
+}

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -12,7 +12,10 @@ import {
 } from '../../results/app/frameworks.ts';
 import { getInfo } from './environment.ts';
 
-import type { VersionOverride } from '../../results/app/types.ts';
+import type {
+  PullRequestNote,
+  VersionOverride,
+} from '../../results/app/types.ts';
 import type { BenchmarkInfo } from './bench-info.ts';
 
 const require = createRequire(import.meta.url);
@@ -146,6 +149,27 @@ export async function saveNotes(frameworks: string[], filePath: string) {
   const file = await read(filePath);
 
   file.notes = { ...file.notes, ...notes };
+
+  await write(file, filePath);
+}
+
+/**
+ * The PRs that landed between the previous result set and this run
+ * (`--include-prs`, from git history). Merged in and deduplicated by URL,
+ * so hand-added entries (plain URL strings) and earlier appends survive.
+ */
+export async function savePrNotes(prs: PullRequestNote[], filePath: string) {
+  if (prs.length === 0) return;
+
+  const file = await read(filePath);
+
+  const existing: Array<string | PullRequestNote> = file.notes?.prs ?? [];
+  const known = new Set(
+    existing.map((pr) => (typeof pr === 'string' ? pr : pr.url)),
+  );
+  const fresh = prs.filter((pr) => !known.has(pr.url));
+
+  file.notes = { ...file.notes, prs: existing.concat(fresh) };
 
   await write(file, filePath);
 }


### PR DESCRIPTION
The latest result set's `notes.prs` was collected by hand ([`6086a0c`](https://github.com/NullVoxPopuli/rere-benchmark/commit/6086a0cc0ae7004e50b8a697bb68a4e3b6508f62)). This adds `--include-prs` so the runner records it instead — from git history alone, no GitHub API.

## How it works

- **"When was the last result set?"** Result files are named with the run's ISO timestamp, so the previous set's date is simply the newest filename in `results/public/results/` other than the file being written — which also does the right thing when appending to today's file (the previous set becomes the one before it).
- **"Which PRs landed since?"** `git log --since=<that date>`, matching both merge shapes:
  - merge commits: `Merge pull request #N from ...` in the subject, PR title as the first body line
  - squash merges: `The PR title (#N)` in the subject

  Deduplicated by number, newest first.
- The list is printed **before** the "does this information look correct?" confirm, so what will be recorded is part of the pre-run review.
- Saved as `notes.prs` entries of `{ url, title }`, merged with whatever is already there and deduplicated by URL — hand-added entries (plain URL strings, like the existing file) and earlier appends survive.

## Results app

The run-info block (`<Info />`) now shows the list in a `<details>`:

> ▸ **PRs since the previous result set (3)**

Runner-recorded entries render as `#76 — <title>`; hand-added string entries render as just `#72` (both link to the PR). The existing 2026-07-29 result set's hand-added notes render as-is, verified in the dev server at 1920px along with the titled shape.

## Verified

- `prs.ts` run against real history: pretending a new file exists yields PRs #76/#74/#75/#73 with correct titles; pretending to append to the 2026-07-29 file yields 9 PRs since the 07-26 set.
- `savePrNotes` on a copy of the real 2026-07-29 file: the three hand-added strings stay, a duplicate of #72 is skipped, #76 appends, and the `vue: { variant: "Vapor" }` note is untouched.
- `ember-tsc --noEmit`, eslint (root + results), and prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
