### PR TITLE
Make timestamps human-readable on history, compare, and results screens

### DIFF
--- a/results/app/components/env.gts
+++ b/results/app/components/env.gts
@@ -1,4 +1,4 @@
-import { formatDuration, msOfFrameAt, throttleLabel } from "#utils";
+import { formatDuration, formatTimestamp, msOfFrameAt, throttleLabel } from "#utils";
 
 import type { TOC } from "@ember/component/template-only";
 import type { ResultSet } from "#types";
@@ -8,10 +8,6 @@ function first8(str: string) {
   return str.slice(0, 8);
 }
 
-function dateOf(datetime: string) {
-  return new Intl.DateTimeFormat("en-CA").format(new Date(datetime));
-}
-
 function isThrottled(cpuThrottle: number | undefined) {
   return typeof cpuThrottle === "number" && cpuThrottle > 1;
 }
@@ -19,7 +15,7 @@ function isThrottled(cpuThrottle: number | undefined) {
 export const Info = <template>
   <div class="env-info">
     Tested on
-    <time datetime={{@date}}>{{dateOf @date}}</time>
+    <time datetime={{@date}}>{{formatTimestamp @date}}</time>
 
     {{#if @sha}}
       <span>

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -404,3 +404,15 @@ table {
 .compare-controls select {
   max-width: 40vw;
 }
+
+/* history: run links line up with their "how long ago" hint */
+.run-list {
+  li {
+    margin-block: 0.25rem;
+  }
+
+  .small {
+    margin-left: 0.5rem;
+    opacity: 0.75;
+  }
+}

--- a/results/app/templates/compare.gts
+++ b/results/app/templates/compare.gts
@@ -12,8 +12,10 @@ import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import { nameOf } from "#frameworks";
 import {
+  formatRunName,
   getFrameworks,
   higherIsBetterBenches,
+  isoOf,
   labelFor,
   lowerIsBetterBenches,
   overrideOf,
@@ -38,10 +40,6 @@ import type { Percentile } from "#utils";
  */
 const SAME_THRESHOLD = 1;
 
-function shortName(runName: string) {
-  return runName.slice(0, 16).replace("T", " ");
-}
-
 function qp(runName: string) {
   return { q: runName };
 }
@@ -54,13 +52,17 @@ function qp(runName: string) {
 const RunOptions = <template>
   <optgroup label="Runs">
     {{#each runs as |name|}}
-      <option value={{name}} selected={{@isRun @which name}}>{{shortName name}}</option>
+      <option value={{name}} selected={{@isRun @which name}} title={{name}}>{{formatRunName
+          name
+        }}</option>
     {{/each}}
   </optgroup>
   {{#if experiments.length}}
     <optgroup label="Experiments">
       {{#each experiments as |name|}}
-        <option value={{name}} selected={{@isRun @which name}}>{{shortName name}}</option>
+        <option value={{name}} selected={{@isRun @which name}} title={{name}}>{{formatRunName
+            name
+          }}</option>
       {{/each}}
     </optgroup>
   {{/if}}
@@ -177,7 +179,9 @@ class CompareTable extends Component<{
         <tr>
           <th></th>
           <th class="run-header">
-            <LinkTo @route="results" @query={{qp @a.name}}>{{shortName @a.name}}</LinkTo>
+            <LinkTo @route="results" @query={{qp @a.name}} title={{@a.name}}>
+              <time datetime={{isoOf @a.name}}>{{formatRunName @a.name}}</time>
+            </LinkTo>
             <span class="small">
               <Version
                 @version={{versionOf @a.data @framework}}
@@ -189,7 +193,9 @@ class CompareTable extends Component<{
             </span>
           </th>
           <th class="run-header">
-            <LinkTo @route="results" @query={{qp @b.name}}>{{shortName @b.name}}</LinkTo>
+            <LinkTo @route="results" @query={{qp @b.name}} title={{@b.name}}>
+              <time datetime={{isoOf @b.name}}>{{formatRunName @b.name}}</time>
+            </LinkTo>
             <span class="small">
               <Version
                 @version={{versionOf @b.data @framework}}

--- a/results/app/templates/history.gts
+++ b/results/app/templates/history.gts
@@ -3,9 +3,28 @@ import { LinkTo } from "@ember/routing";
 import { pageTitle } from "ember-page-title";
 import { experiments, runs } from "virtual:result-sets";
 
+import { formatRunName, isoOf, relativeToNow } from "#utils";
+
+import type { TOC } from "@ember/component/template-only";
+
 function qp(resultName: string) {
   return { q: resultName };
 }
+
+const ResultList = <template>
+  <nav>
+    <ul class="run-list">
+      {{#each @names as |resultName|}}
+        <li>
+          <LinkTo @route="results" @query={{qp resultName}} title={{resultName}}>
+            <time datetime={{isoOf resultName}}>{{formatRunName resultName}}</time>
+          </LinkTo>
+          <span class="small">{{relativeToNow resultName}}</span>
+        </li>
+      {{/each}}
+    </ul>
+  </nav>
+</template> satisfies TOC<{ names: string[] }>;
 
 <template>
   {{pageTitle "History"}}
@@ -15,33 +34,13 @@ function qp(resultName: string) {
 
     <section>
       <h2>Runs</h2>
-      <nav>
-        <ul>
-          {{#each runs as |resultName|}}
-            <li>
-              <LinkTo @route="results" @query={{qp resultName}}>
-                {{resultName}}
-              </LinkTo>
-            </li>
-          {{/each}}
-        </ul>
-      </nav>
+      <ResultList @names={{runs}} />
     </section>
 
     {{#if experiments.length}}
       <section>
         <h2>Experiments</h2>
-        <nav>
-          <ul>
-            {{#each experiments as |resultName|}}
-              <li>
-                <LinkTo @route="results" @query={{qp resultName}}>
-                  {{resultName}}
-                </LinkTo>
-              </li>
-            {{/each}}
-          </ul>
-        </nav>
+        <ResultList @names={{experiments}} />
       </section>
     {{/if}}
   </main>

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -152,13 +152,13 @@ export function formatDuration(ms: number): string {
 }
 
 /**
- * Result-set names are ISO timestamps (`2026-07-29T16:32:44.768Z`), with an
- * optional experiment prefix (`ember-2026-07-29T...`). Raw ISO strings are
- * hard to scan, so anywhere a run name is *displayed* it gets formatted for
- * the viewer's locale; the raw name stays in URLs and `datetime` / `title`
- * attributes.
+ * Result-set names end in a `Date#toISOString` timestamp
+ * (`2026-07-29T16:32:44.768Z`), optionally preceded by an experiment prefix
+ * (`ember-2026-07-29T...`). Raw ISO strings are hard to scan, so anywhere a
+ * run name is *displayed* it gets formatted for the viewer's locale; the raw
+ * name stays in URLs and `datetime` / `title` attributes.
  */
-const RUN_NAME = /^(?:(.+)-)?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)$/;
+const ISO_TIMESTAMP_LENGTH = "2026-07-29T16:32:44.768Z".length;
 
 const TIMESTAMP_FORMAT = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
@@ -172,18 +172,30 @@ export function formatTimestamp(datetime: string) {
 /**
  * The ISO timestamp within a run name, for `<time datetime>`.
  * `undefined` for names that don't follow the timestamp convention.
+ *
+ * `Date#toISOString` output is fixed-length, so the timestamp is the name's
+ * tail; it's genuine when the platform parses it and round-trips back to the
+ * exact same string.
  */
 export function isoOf(runName: string) {
-  return RUN_NAME.exec(runName)?.[2];
+  const candidate = runName.slice(-ISO_TIMESTAMP_LENGTH);
+  const date = new Date(candidate);
+
+  if (Number.isNaN(date.getTime()) || date.toISOString() !== candidate) {
+    return undefined;
+  }
+
+  return candidate;
 }
 
 export function formatRunName(runName: string) {
-  const match = RUN_NAME.exec(runName);
+  const iso = isoOf(runName);
 
-  if (!match) return runName;
+  if (!iso) return runName;
 
-  const [, prefix, iso] = match;
-  const formatted = formatTimestamp(iso as string);
+  const formatted = formatTimestamp(iso);
+  const joined = runName.slice(0, runName.length - iso.length);
+  const prefix = joined.endsWith("-") ? joined.slice(0, -1) : joined;
 
   return prefix ? `${prefix} · ${formatted}` : formatted;
 }

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -151,6 +151,74 @@ export function formatDuration(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
+/**
+ * Result-set names are ISO timestamps (`2026-07-29T16:32:44.768Z`), with an
+ * optional experiment prefix (`ember-2026-07-29T...`). Raw ISO strings are
+ * hard to scan, so anywhere a run name is *displayed* it gets formatted for
+ * the viewer's locale; the raw name stays in URLs and `datetime` / `title`
+ * attributes.
+ */
+const RUN_NAME = /^(?:(.+)-)?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)$/;
+
+const TIMESTAMP_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+export function formatTimestamp(datetime: string) {
+  return TIMESTAMP_FORMAT.format(new Date(datetime));
+}
+
+/**
+ * The ISO timestamp within a run name, for `<time datetime>`.
+ * `undefined` for names that don't follow the timestamp convention.
+ */
+export function isoOf(runName: string) {
+  return RUN_NAME.exec(runName)?.[2];
+}
+
+export function formatRunName(runName: string) {
+  const match = RUN_NAME.exec(runName);
+
+  if (!match) return runName;
+
+  const [, prefix, iso] = match;
+  const formatted = formatTimestamp(iso as string);
+
+  return prefix ? `${prefix} · ${formatted}` : formatted;
+}
+
+const RELATIVE_FORMAT = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const RELATIVE_STEPS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ["year", 365 * 24 * 3_600_000],
+  ["month", 30 * 24 * 3_600_000],
+  ["week", 7 * 24 * 3_600_000],
+  ["day", 24 * 3_600_000],
+  ["hour", 3_600_000],
+  ["minute", 60_000],
+];
+
+/**
+ * "3 days ago" for the timestamp in a run name; empty for names that don't
+ * follow the timestamp convention, so templates can render it unconditionally.
+ */
+export function relativeToNow(runName: string) {
+  const iso = isoOf(runName);
+
+  if (!iso) return "";
+
+  const delta = new Date(iso).getTime() - Date.now();
+
+  for (const [unit, ms] of RELATIVE_STEPS) {
+    if (Math.abs(delta) >= ms || unit === "minute") {
+      return RELATIVE_FORMAT.format(Math.round(delta / ms), unit);
+    }
+  }
+
+  return "";
+}
+
 const msInOneHz = 1_000;
 
 export function msOfFrameAt(hz: number) {

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -202,33 +202,38 @@ export function formatRunName(runName: string) {
 
 const RELATIVE_FORMAT = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 
-const RELATIVE_STEPS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
-  ["year", 365 * 24 * 3_600_000],
-  ["month", 30 * 24 * 3_600_000],
-  ["week", 7 * 24 * 3_600_000],
-  ["day", 24 * 3_600_000],
-  ["hour", 3_600_000],
-  ["minute", 60_000],
-];
+// most-significant-first; weeks are omitted because `until` only populates
+// them when they're the largest unit requested
+const DURATION_UNITS = ["year", "month", "day", "hour", "minute", "second"] as const;
 
 /**
  * "3 days ago" for the timestamp in a run name; empty for names that don't
  * follow the timestamp convention, so templates can render it unconditionally.
+ *
+ * Temporal does the calendar-aware breakdown and `Intl.RelativeTimeFormat`
+ * the wording; all that's left to us is picking the duration's most
+ * significant non-zero unit. Temporal is ES2026 but not yet in Safari, so
+ * the hint is simply absent there.
  */
 export function relativeToNow(runName: string) {
   const iso = isoOf(runName);
 
   if (!iso) return "";
+  if (!("Temporal" in globalThis)) return "";
 
-  const delta = new Date(iso).getTime() - Date.now();
+  const timeZone = Temporal.Now.timeZoneId();
+  const then = Temporal.Instant.from(iso).toZonedDateTimeISO(timeZone);
+  const duration = then.until(Temporal.Now.zonedDateTimeISO(), { largestUnit: "year" });
 
-  for (const [unit, ms] of RELATIVE_STEPS) {
-    if (Math.abs(delta) >= ms || unit === "minute") {
-      return RELATIVE_FORMAT.format(Math.round(delta / ms), unit);
+  for (const unit of DURATION_UNITS) {
+    const elapsed = duration[`${unit}s`];
+
+    if (elapsed !== 0) {
+      return RELATIVE_FORMAT.format(-elapsed, unit);
     }
   }
 
-  return "";
+  return RELATIVE_FORMAT.format(0, "second");
 }
 
 const msInOneHz = 1_000;

--- a/results/types/temporal.d.ts
+++ b/results/types/temporal.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Temporal is ES2026 (Chrome 144+ / Firefox 139+ / Edge 144+), but
+ * TypeScript's lib doesn't declare it yet — this declares just the surface
+ * used in `app/utils.ts` (`relativeToNow`). Delete once `lib` catches up.
+ */
+declare namespace Temporal {
+  interface Duration {
+    years: number;
+    months: number;
+    weeks: number;
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+  }
+
+  interface ZonedDateTime {
+    until(other: ZonedDateTime, options: { largestUnit: "year" }): Duration;
+  }
+
+  interface Instant {
+    toZonedDateTimeISO(timeZone: string): ZonedDateTime;
+  }
+
+  const Instant: {
+    from(iso: string): Instant;
+  };
+
+  const Now: {
+    timeZoneId(): string;
+    zonedDateTimeISO(): ZonedDateTime;
+  };
+}


### PR DESCRIPTION
Run names are ISO timestamps (`2026-07-29T16:32:44.768Z`) and were shown raw on the history screen and sliced (`slice(0, 16)`) on the compare screen — which also mangled prefixed experiment names like `ember-2026-07-29T...` into `ember-2026-07-29`, dropping the time entirely.

Everywhere a run name is *displayed*, it's now formatted for the viewer's locale via shared `#utils` formatters (`formatRunName` / `formatTimestamp` / `relativeToNow`, backed by `Intl.DateTimeFormat` + `Intl.RelativeTimeFormat`):

- **history**: `Jul 29, 2026, 12:32 PM` links (in `<time datetime>` elements) with a muted "5 hours ago" hint next to each run; experiments keep their prefix: `ember · Jul 29, 2026, 5:11 PM`
- **compare**: the A/B run selectors and the table run-header links use the same format
- **results**: the "Tested on" line gains the time of day (was date-only `2026-07-29`)

The raw name stays as the query param and is still reachable via each link/option's `title` attribute (hover), so correlating with the JSON file names remains easy.

Verified in the browser at 1920px on all three screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
