### PR TITLE
Add `pnpm bench:add`: interactively add/replace one framework in an existing result set

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ window you've covered up.
 | flag | default | |
 | --- | --- | --- |
 | `--framework` | prompts | a framework name, or `all` |
-| `--bench` | prompts | a benchmark's display name, or `all` |
+| `--bench` | prompts | a benchmark's display name, or `all`; repeat the flag to select several |
 | `--count` | `10` | samples per bench per framework |
 | `--cpu-throttle` | `1` | emulated CPU slowdown; runs at different settings are not comparable |
 | `--headless` | off | headless caps at 60fps, so the frame-rate bench means less |
@@ -265,7 +265,9 @@ An interactive wrapper around `pnpm bench` for when a result set (or
 added to it -- or re-run and replaced (runs are stored by framework name,
 so a re-run overwrites the previous ones).
 
-It walks through picking the file and the framework, re-uses the
+It walks through picking the file, the framework, and which of the file's
+benches to run -- all of them by default; a subset replaces just those of
+the framework's runs and leaves the rest alone. It re-uses the
 `--cpu-throttle` / `--count` / `--timeout` / `--headless` settings recorded
 in the file (mixing settings within a file would make its numbers
 incomparable), and then hands off to `pnpm bench` with those flags.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,23 @@ window you've covered up.
 | `--timeout` | `60000` | ms a single sample may take before the run fails |
 | `--skip-build` | off | re-use an existing build |
 | `--include-prs` | off | record the PRs that landed since the previous result set in the run's notes (from git history; shown in the results app) |
+| `--file` | prompts | append to this existing result file; the bench selection comes from the file, so only `--framework` is left to pick |
+
+### Adding one framework to an existing result set
+
+```bash
+pnpm bench:add
+```
+
+An interactive wrapper around `pnpm bench` for when a result set (or
+`use-tar-for` experiment) already exists and one framework needs to be
+added to it -- or re-run and replaced (runs are stored by framework name,
+so a re-run overwrites the previous ones).
+
+It walks through picking the file and the framework, re-uses the
+`--cpu-throttle` / `--count` / `--timeout` / `--headless` settings recorded
+in the file (mixing settings within a file would make its numbers
+incomparable), and then hands off to `pnpm bench` with those flags.
 
 ### Query params
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ the framework's runs and leaves the rest alone. It re-uses the
 in the file (mixing settings within a file would make its numbers
 incomparable), and then hands off to `pnpm bench` with those flags.
 
+Hardware is held to the same standard: appending to a file recorded on a
+different machine (cpu, ram, or monitor refresh rate) is an error, and an
+OS or browser difference is warned about.
+
 ### Query params
 
 The apps read their own config from the URL, so you can open any bench and

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "copy": "node --experimental-strip-types ./src/runner/copy.ts",
     "use-tar-for": "node --experimental-strip-types ./src/runner/use-tar-for.ts",
     "bench": "node --experimental-strip-types ./src/runner/index.ts",
+    "bench:add": "node --experimental-strip-types ./src/runner/add.ts",
     "bench:one": "pnpm bench --bench=all --cpu-throttle=4",
     "bench:all": "pnpm bench --framework=all --bench=all --cpu-throttle=4"
   },

--- a/src/runner/add.ts
+++ b/src/runner/add.ts
@@ -1,0 +1,187 @@
+/**
+ * `pnpm bench:add`
+ *
+ * Walks through adding one framework's runs to an existing result set --
+ * or replacing the runs it already has (same name) -- using the settings
+ * the file was recorded with. Ends by handing off to `pnpm bench` with
+ * the equivalent flags, so the run itself is the same code path as always.
+ *
+ * Deliberately does not import arg.ts (directly or via repo.ts): importing
+ * it prints the runner's flag table, which describes the flags of *this*
+ * process rather than the ones this wizard assembles.
+ */
+import assert from 'node:assert';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import * as clack from '@clack/prompts';
+import { $ } from 'execa';
+
+const RESULT_DIRS = [
+  { dir: 'results/public/results', kind: 'result' },
+  { dir: 'results/public/experiments', kind: 'experiment' },
+] as const;
+
+interface Candidate {
+  path: string;
+  kind: (typeof RESULT_DIRS)[number]['kind'];
+  modifiedAt: number;
+}
+
+async function listResultFiles() {
+  const candidates: Candidate[] = [];
+
+  for (const { dir, kind } of RESULT_DIRS) {
+    let entries: string[];
+
+    try {
+      entries = await readdir(dir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) continue;
+
+      const path = join(dir, entry);
+      const { mtimeMs } = await stat(path);
+
+      candidates.push({ path, kind, modifiedAt: mtimeMs });
+    }
+  }
+
+  return candidates.sort((a, b) => b.modifiedAt - a.modifiedAt);
+}
+
+function exitOnCancel<T>(value: T | symbol): T {
+  if (clack.isCancel(value)) {
+    clack.cancel('Cancelled');
+    process.exit(1);
+  }
+
+  return value as T;
+}
+
+clack.intro(`Add (or replace) one framework in an existing result set`);
+
+const candidates = await listResultFiles();
+
+assert(
+  candidates.length > 0,
+  `No result sets found in ${RESULT_DIRS.map(({ dir }) => dir).join(' or ')} -- run \`pnpm bench\` first`,
+);
+
+const target = exitOnCancel(
+  await clack.select({
+    message: 'Which result set?',
+    options: candidates.map((candidate) => {
+      return { value: candidate, label: candidate.path, hint: candidate.kind };
+    }),
+  }),
+);
+
+const file = JSON.parse((await readFile(target.path)).toString());
+const recordedArgs = file.args ?? {};
+const already = Object.keys(file.results ?? {});
+
+if (!file.args) {
+  clack.log.warn(
+    `${target.path} does not record the flags it ran with; falling back to the runner's defaults`,
+  );
+}
+
+clack.log.info(
+  [
+    `Recorded in ${target.path}:`,
+    `  cpu-throttle: ${recordedArgs.CPU_THROTTLE ?? 1}`,
+    `  count:        ${recordedArgs.COUNT ?? 10}`,
+    `  timeout:      ${recordedArgs.TIMEOUT ?? 60_000}`,
+    `  headless:     ${recordedArgs.HEADLESS ?? false}`,
+    `  benches:      ${file.selections?.benches?.length ?? '(unknown)'}`,
+    `  frameworks:   ${already.join(', ') || '(none yet)'}`,
+  ].join('\n'),
+);
+
+const frameworksDir = await readdir('frameworks', { withFileTypes: true });
+const available = frameworksDir
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const framework = exitOnCancel(
+  await clack.select({
+    message: 'Which framework?',
+    options: available.map((name) => {
+      return {
+        value: name,
+        label: name,
+        hint: already.includes(name) ? 'replace its existing runs' : 'add',
+      };
+    }),
+  }),
+);
+
+const flags = [
+  `--framework=${framework}`,
+  `--file=${target.path}`,
+  `--cpu-throttle=${recordedArgs.CPU_THROTTLE ?? 1}`,
+  `--count=${recordedArgs.COUNT ?? 10}`,
+  `--timeout=${recordedArgs.TIMEOUT ?? 60_000}`,
+];
+
+if (recordedArgs.HEADLESS) {
+  flags.push('--headless');
+}
+
+/**
+ * A `use-tar-for` experiment labels the framework with the PR its build
+ * came from. Replacing those runs with a normally-installed build while
+ * the label sticks around would misattribute the new numbers.
+ */
+const override = file.versionOverrides?.[framework];
+
+if (override) {
+  const stillFromPr = exitOnCancel(
+    await clack.confirm({
+      message:
+        `This file labels ${framework} as built from ${override.url}. ` +
+        `Is this run also from that PR (the use-tar-for tarball is still installed)?`,
+      initialValue: false,
+    }),
+  );
+
+  if (stillFromPr) {
+    flags.push(`--${framework}=${override.url}`);
+  } else {
+    delete file.versionOverrides[framework];
+
+    if (Object.keys(file.versionOverrides).length === 0) {
+      delete file.versionOverrides;
+    }
+
+    await writeFile(target.path, JSON.stringify(file, null, 2));
+    clack.log.info(`Removed the ${override.url} label from ${target.path}`);
+  }
+}
+
+const build = exitOnCancel(
+  await clack.confirm({
+    message: `Build ${framework}'s apps first? (choose no to re-use existing dist folders)`,
+    initialValue: true,
+  }),
+);
+
+if (!build) {
+  flags.push('--skip-build');
+}
+
+clack.log.info(`Running: pnpm bench ${flags.join(' ')}`);
+clack.outro('Handing off to the benchmark runner');
+
+const result = await $({
+  preferLocal: true,
+  stdio: 'inherit',
+  reject: false,
+})`pnpm bench ${flags}`;
+
+process.exit(result.exitCode ?? 1);

--- a/src/runner/add.ts
+++ b/src/runner/add.ts
@@ -11,7 +11,7 @@
  * process rather than the ones this wizard assembles.
  */
 import assert from 'node:assert';
-import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import * as clack from '@clack/prompts';
@@ -133,34 +133,28 @@ if (recordedArgs.HEADLESS) {
   flags.push('--headless');
 }
 
-/**
- * A `use-tar-for` experiment labels the framework with the PR its build
- * came from. Replacing those runs with a normally-installed build while
- * the label sticks around would misattribute the new numbers.
- */
-const override = file.versionOverrides?.[framework];
+const recordedBenches: string[] = file.selections?.benches ?? [];
 
-if (override) {
-  const stillFromPr = exitOnCancel(
-    await clack.confirm({
-      message:
-        `This file labels ${framework} as built from ${override.url}. ` +
-        `Is this run also from that PR (the use-tar-for tarball is still installed)?`,
-      initialValue: false,
+if (recordedBenches.length > 1) {
+  const benches = exitOnCancel(
+    await clack.multiselect({
+      message: `Which benches? (a subset replaces just those of ${framework}'s runs)`,
+      options: recordedBenches.map((name) => {
+        return { value: name, label: name };
+      }),
+      initialValues: recordedBenches,
     }),
   );
 
-  if (stillFromPr) {
-    flags.push(`--${framework}=${override.url}`);
-  } else {
-    delete file.versionOverrides[framework];
-
-    if (Object.keys(file.versionOverrides).length === 0) {
-      delete file.versionOverrides;
+  /**
+   * All of them selected means no flag: the runner then takes its
+   * selection from the file, exactly as if the subset question was
+   * never asked.
+   */
+  if (benches.length < recordedBenches.length) {
+    for (const name of benches) {
+      flags.push(`--bench=${name}`);
     }
-
-    await writeFile(target.path, JSON.stringify(file, null, 2));
-    clack.log.info(`Removed the ${override.url} label from ${target.path}`);
   }
 }
 
@@ -175,7 +169,11 @@ if (!build) {
   flags.push('--skip-build');
 }
 
-clack.log.info(`Running: pnpm bench ${flags.join(' ')}`);
+const printable = flags
+  .map((flag) => (flag.includes(' ') ? `"${flag}"` : flag))
+  .join(' ');
+
+clack.log.info(`Running: pnpm bench ${printable}`);
 clack.outro('Handing off to the benchmark runner');
 
 const result = await $({

--- a/src/runner/arg.ts
+++ b/src/runner/arg.ts
@@ -17,6 +17,7 @@ export const COUNT = int('--count', 10);
 export const CPU_THROTTLE = int('--cpu-throttle', 1);
 export const FRAMEWORK = str('--framework');
 export const BENCH_NAME = str('--bench');
+export const BENCH_NAMES = strAll('--bench');
 export const SKIP_BUILD = bool('--skip-build');
 export const TIMEOUT = int('--timeout', 60_000);
 export const INCLUDE_PRS = bool('--include-prs');
@@ -58,7 +59,11 @@ console.log(
     row(col1('--count'), col2(COUNT), col3('sample count')),
     row(col1('--timeout'), col2(TIMEOUT), col3('ms a single sample may take')),
     row(col1('--framework'), col2(FRAMEWORK), col3(`or '${ALL}'`)),
-    row(col1('--bench'), col2(BENCH_NAME), col3(`or '${ALL}'`)),
+    row(
+      col1('--bench'),
+      col2(BENCH_NAME),
+      col3(`or '${ALL}'; repeatable to select several`),
+    ),
     row(
       col1('--include-prs'),
       col2(INCLUDE_PRS),
@@ -89,6 +94,16 @@ function str(name: string) {
   const arg = args.find((a) => a.startsWith(name));
 
   return arg?.split('=')[1];
+}
+
+/**
+ * A flag that may be repeated -- `--bench=X --bench=Y` selects both.
+ */
+function strAll(name: string) {
+  return args
+    .filter((a) => a.split('=')[0] === name)
+    .map((a) => a.split('=').slice(1).join('='))
+    .filter(Boolean);
 }
 
 /**

--- a/src/runner/arg.ts
+++ b/src/runner/arg.ts
@@ -20,6 +20,7 @@ export const BENCH_NAME = str('--bench');
 export const SKIP_BUILD = bool('--skip-build');
 export const TIMEOUT = int('--timeout', 60_000);
 export const INCLUDE_PRS = bool('--include-prs');
+export const FILE = str('--file');
 export const VERSION_OVERRIDES = versionOverrides();
 
 function col1(name: string) {
@@ -27,7 +28,8 @@ function col1(name: string) {
 }
 
 function col2(value: unknown) {
-  return String(value ?? '').padEnd(10);
+  // the trailing space keeps a separator when the value overflows the pad
+  return (String(value ?? '') + ' ').padEnd(10);
 }
 
 function col3(description: string) {
@@ -61,6 +63,11 @@ console.log(
       col1('--include-prs'),
       col2(INCLUDE_PRS),
       col3('record PRs merged since the previous result set'),
+    ),
+    row(
+      col1('--file'),
+      col2(FILE),
+      col3('append to this result file, re-using its bench selection'),
     ),
     ...Object.entries(VERSION_OVERRIDES).map(([framework, override]) =>
       row(

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
-import { readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
 import { inspect } from 'node:util';
 
 import * as clack from '@clack/prompts';
@@ -227,6 +228,23 @@ async function getFrameworks() {
   return selectedFrameworks;
 }
 
+/**
+ * The bench selection recorded in an existing result file, so `--file`
+ * (and `pnpm bench:add` on top of it) re-runs exactly what the file holds.
+ */
+async function benchNamesFrom(filePath: string) {
+  const buffer = await readFile(filePath);
+  const file = JSON.parse(buffer.toString());
+  const names: unknown = file.selections?.benches;
+
+  assert(
+    Array.isArray(names) && names.length > 0,
+    `${filePath} does not record which benches it ran (selections.benches)`,
+  );
+
+  return names as string[];
+}
+
 async function getBenches() {
   if (args.BENCH_NAME === args.ALL) {
     return benchmarks;
@@ -241,6 +259,33 @@ async function getBenches() {
   let selectedBenches: BenchmarkInfo[] | undefined = preselected
     ? [preselected]
     : undefined;
+
+  if (!selectedBenches && args.FILE) {
+    const names = await benchNamesFrom(args.FILE);
+    const known = benchmarks.filter((bench) => names.includes(bench.name));
+    const unknown = names.filter(
+      (name) => !known.some((bench) => bench.name === name),
+    );
+
+    if (unknown.length > 0) {
+      clack.log.warn(
+        `Benches recorded in ${args.FILE} that no longer exist (skipped):\n` +
+          unknown.map((name) => `  ${name}`).join('\n'),
+      );
+    }
+
+    assert(
+      known.length > 0,
+      `None of the benches recorded in ${args.FILE} exist anymore`,
+    );
+
+    clack.log.info(
+      `Benches recorded in ${args.FILE}:\n` +
+        known.map((bench) => `  ${bench.name}`).join('\n'),
+    );
+
+    selectedBenches = known;
+  }
 
   if (!selectedBenches) {
     const result = await clack.multiselect({
@@ -264,6 +309,15 @@ async function getBenches() {
 const yesterdayFull = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
 async function getFilePath() {
+  if (args.FILE) {
+    assert(
+      existsSync(args.FILE),
+      `--file=${args.FILE} does not exist -- it appends to a result set that has already been created`,
+    );
+
+    return args.FILE;
+  }
+
   let existing = await readdir(`./results/public/results/`);
 
   const today = yyyymmdd.split('T')[0]!;

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -245,65 +245,62 @@ async function benchNamesFrom(filePath: string) {
   return names as string[];
 }
 
+/**
+ * The named benches, warning about names that do not match any bench --
+ * a rename since the names were recorded, or a typo.
+ */
+function benchesNamed(names: string[], source: string) {
+  const known = benchmarks.filter((bench) => names.includes(bench.name));
+  const unknown = names.filter(
+    (name) => !known.some((bench) => bench.name === name),
+  );
+
+  if (unknown.length > 0) {
+    clack.log.warn(
+      `Bench names from ${source} that do not exist (skipped):\n` +
+        unknown.map((name) => `  ${name}`).join('\n'),
+    );
+  }
+
+  assert(known.length > 0, `No existing benches were named by ${source}`);
+
+  return known;
+}
+
 async function getBenches() {
   if (args.BENCH_NAME === args.ALL) {
     return benchmarks;
   }
 
-  let preselected: BenchmarkInfo | undefined;
-
-  if (args.BENCH_NAME) {
-    preselected = benchmarks.find((bench) => bench.name === args.BENCH_NAME);
+  if (args.BENCH_NAMES.length > 0) {
+    return benchesNamed(args.BENCH_NAMES, '--bench');
   }
 
-  let selectedBenches: BenchmarkInfo[] | undefined = preselected
-    ? [preselected]
-    : undefined;
-
-  if (!selectedBenches && args.FILE) {
+  if (args.FILE) {
     const names = await benchNamesFrom(args.FILE);
-    const known = benchmarks.filter((bench) => names.includes(bench.name));
-    const unknown = names.filter(
-      (name) => !known.some((bench) => bench.name === name),
-    );
-
-    if (unknown.length > 0) {
-      clack.log.warn(
-        `Benches recorded in ${args.FILE} that no longer exist (skipped):\n` +
-          unknown.map((name) => `  ${name}`).join('\n'),
-      );
-    }
-
-    assert(
-      known.length > 0,
-      `None of the benches recorded in ${args.FILE} exist anymore`,
-    );
+    const known = benchesNamed(names, args.FILE);
 
     clack.log.info(
       `Benches recorded in ${args.FILE}:\n` +
         known.map((bench) => `  ${bench.name}`).join('\n'),
     );
 
-    selectedBenches = known;
+    return known;
   }
 
-  if (!selectedBenches) {
-    const result = await clack.multiselect({
-      message: 'Which benchmarks?',
-      options: benchmarks.map((b) => {
-        return { value: b, label: b.name };
-      }),
-    });
+  const result = await clack.multiselect({
+    message: 'Which benchmarks?',
+    options: benchmarks.map((b) => {
+      return { value: b, label: b.name };
+    }),
+  });
 
-    if (clack.isCancel(result)) {
-      clack.log.info('Cancelled');
-      process.exit(1);
-    }
-
-    selectedBenches = result;
+  if (clack.isCancel(result)) {
+    clack.log.info('Cancelled');
+    process.exit(1);
   }
 
-  return selectedBenches;
+  return result;
 }
 
 const yesterdayFull = new Date(Date.now() - 24 * 60 * 60 * 1000);

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -10,6 +10,7 @@ import { yyyymmdd } from './environment.ts';
 import { prsSinceLastResultSet } from './prs.ts';
 import { frameworks } from './repo.ts';
 import {
+  assertSameEnvironment,
   info,
   saveBenchmarkInfo,
   saveNotes,
@@ -353,6 +354,8 @@ export async function getBenchInfo() {
 
   const selectedBenches = await getBenches();
   const filePath = await getFilePath();
+
+  await assertSameEnvironment(filePath);
 
   // resolved before the confirm below, so what will be recorded is part
   // of the "does this look correct?" review

--- a/src/runner/results.ts
+++ b/src/runner/results.ts
@@ -54,6 +54,66 @@ async function saveResults(results: any, filePath: string) {
   await write(file, filePath);
 }
 
+/**
+ * Numbers in one file must be comparable, and hardware is part of the
+ * measurement: appending runs from a different machine (or a different
+ * monitor -- the frame-rate bench is capped by its refresh rate) would mix
+ * results that cannot be compared.
+ */
+export async function assertSameEnvironment(filePath: string) {
+  if (!existsSync(filePath)) return;
+
+  const file = await read(filePath);
+  const recorded = file.environment;
+
+  if (!recorded) {
+    return;
+  }
+
+  const current = info.environment;
+  const mismatches: string[] = [];
+
+  if (recorded.machine?.cpu !== current.machine.cpu) {
+    mismatches.push(`cpu: ${recorded.machine?.cpu} vs ${current.machine.cpu}`);
+  }
+
+  if (recorded.machine?.ram !== current.machine.ram) {
+    mismatches.push(`ram: ${recorded.machine?.ram} vs ${current.machine.ram}`);
+  }
+
+  if (recorded.monitor?.hz !== current.monitor.hz) {
+    mismatches.push(
+      `monitor: ${recorded.monitor?.hz}hz vs ${current.monitor.hz}hz`,
+    );
+  }
+
+  assert(
+    mismatches.length === 0,
+    `${filePath} was recorded on different hardware (recorded vs now):\n` +
+      mismatches.map((mismatch) => `  ${mismatch}`).join('\n'),
+  );
+
+  /**
+   * Not hardware, so not fatal -- but an OS or browser update between runs
+   * is still worth knowing about when reading the numbers later.
+   */
+  if (
+    JSON.stringify(recorded.machine?.os) !== JSON.stringify(current.machine.os)
+  ) {
+    console.warn(
+      `${filePath} was recorded on ${recorded.machine?.os?.name} ${recorded.machine?.os?.version}, ` +
+        `this is ${current.machine.os.name} ${current.machine.os.version}`,
+    );
+  }
+
+  if (JSON.stringify(recorded.browser) !== JSON.stringify(current.browser)) {
+    console.warn(
+      `${filePath} was recorded with ${recorded.browser?.name} ${recorded.browser?.version}, ` +
+        `this is ${current.browser.name} ${current.browser.version}`,
+    );
+  }
+}
+
 export interface Timing {
   /**
    * Wall-clock time (ms) spent installing + building all apps.


### PR DESCRIPTION
## What

`pnpm bench:add` — an interactive wrapper around `pnpm bench` for when a result set (or `use-tar-for` experiment) already exists and one framework needs to be added to it, or re-run and replaced (runs are stored by framework name, so a re-run overwrites that framework's previous runs).

The wizard:

1. lists every file in `results/public/results/` and `results/public/experiments/` (newest first, labeled by kind) and asks which one,
2. shows the settings recorded in it (`cpu-throttle`, `count`, `timeout`, `headless`, benches, frameworks already present),
3. asks which framework, hinting which ones would be **replaced** vs added,
4. asks which of the file's benches to run — all by default; a subset replaces just those of the framework's runs and leaves the rest alone,
5. asks whether to build first (no → `--skip-build`),
6. hands off to `pnpm bench` with the equivalent flags — the run itself stays on the usual code path, and the runner's own "does this look correct?" confirm remains the final gate. It also prints the assembled command (shell-quoted), so it can be re-run directly.

Since mixing settings within one file makes its numbers incomparable, everything is taken from the file's recorded `args` rather than asked.

### Runner flags

- `--file=<path>` skips the save-location prompt (which only offers today/yesterday) and re-uses the bench selection recorded in the file's `selections.benches` — with a warning for recorded bench names that no longer exist. The selected benches are echoed before the confirm.
- `--bench` is now repeatable: `--bench=X --bench=Y` selects both (bench names contain commas, so a comma-separated form was out).

### Drive-by fix

The startup flag table lost its column separator when a value overflowed the 10-char pad (visible with `--file`'s long paths: `…json​append to…`); a trailing space keeps it.

## Testing

Drove the wizard through a pty (pexpect) against scratch copies of a real result file (shrunk to 1-2 benches, `COUNT: 2`, ember-only results):

- **Replace + abort**: picked ember → "replace its existing runs" hint shown, `--skip-build` assembled, aborted at the runner's confirm → exit 1 propagated, results untouched.
- **Add + full run**: picked preact → benchmark actually ran (2 samples), preact appended with its real installed version, ember's 10 samples kept, `selections.frameworks` merged to `["ember", "preact"]`.
- **Bench subset**: two-bench file, deselected one → `--bench="1 item, 1k updates"` passed through, that bench's runs replaced (10 → 2 samples), the other bench's 10 samples and `selections` untouched.

`pnpm lint:js` and `pnpm lint:prettier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)