### PR TITLE
Measure the Preact signal-binding rewrite; keep it only where it wins

### DIFF
--- a/frameworks/preact/dbmon-with-chat/src/App.tsx
+++ b/frameworks/preact/dbmon-with-chat/src/App.tsx
@@ -1,18 +1,16 @@
 import 'common/dbmon.css';
 import './layout.css';
-import { useLayoutEffect } from 'preact/hooks';
-import { signal, batch, useComputed } from '@preact/signals';
+import { useLayoutEffect, useMemo } from 'preact/hooks';
+import { batch, signal, useComputed, useSignal } from '@preact/signals';
 import { For } from '@preact/signals/utils';
 import { helpers, type DBRow, type ChatMessage, type DBUpdate, type ChatUpdate } from 'common';
 import type { Signal } from '@preact/signals';
 
 const test = helpers.dbMonWithChat();
 
-// One signal per row keyed by dbname; only the affected row re-renders on update.
-const rowMap = new Map<string, Signal<DBRow>>();
-const dbRows = signal<Signal<DBRow>[]>([]);
-const chats = signal<ChatMessage[]>([]);
-
+// one signal per row: writing it updates only that row's bindings, so a
+// worker message re-renders nothing -- the changed text nodes update in
+// place (measured: ~27fps vs ~18fps for swap-the-whole-Map, throttle x8)
 function Row({ row }: { row: Signal<DBRow> }) {
   const dbname = useComputed(() => row.value.dbname);
   const countClassName = useComputed(() => row.value.lastSample.countClassName);
@@ -40,7 +38,7 @@ function Row({ row }: { row: Signal<DBRow> }) {
   );
 }
 
-function ChatList() {
+function ChatList({ chats }: { chats: Signal<ChatMessage[]> }) {
   return (
     <For each={chats}>
       {(chat) => (
@@ -54,19 +52,31 @@ function ChatList() {
 }
 
 function App() {
+  const rows = useSignal<Signal<DBRow>[]>([]);
+  const chats = useSignal<ChatMessage[]>([]);
+  // index into `rows` by dbname; not reactive state, just a lookup
+  const rowMap = useMemo(() => new Map<string, Signal<DBRow>>(), []);
+
   useLayoutEffect(() => {
     test.doit({
       handleDbUpdate: (eventData: DBUpdate) => {
         batch(() => {
+          let added: Signal<DBRow>[] | undefined;
+
           for (const d of eventData.data) {
             const existing = rowMap.get(d.dbname);
+
             if (existing) {
               existing.value = d;
             } else {
               const row = signal(d);
               rowMap.set(d.dbname, row);
-              dbRows.value = [...dbRows.value, row];
+              (added ??= []).push(row);
             }
+          }
+
+          if (added) {
+            rows.value = rows.value.concat(added);
           }
         });
       },
@@ -88,7 +98,7 @@ function App() {
           </tr>
         </thead>
         <tbody>
-          <For each={dbRows}>
+          <For each={rows}>
             {(row) => <Row row={row} />}
           </For>
         </tbody>
@@ -97,7 +107,7 @@ function App() {
       <div className="chats">
         <div className="messages">
           <div className="messages-inner">
-            <ChatList />
+            <ChatList chats={chats} />
           </div>
         </div>
         <div className="entry">

--- a/frameworks/preact/fan-out/src/App.tsx
+++ b/frameworks/preact/fan-out/src/App.tsx
@@ -1,12 +1,11 @@
 import { useLayoutEffect } from 'preact/hooks'
-import { useSignal, useComputed } from '@preact/signals'
+import { useSignal } from '@preact/signals'
 import { helpers } from 'common';
 
 const test = helpers.fanOut();
 
 function App() {
   const value = useSignal(test.getData());
-  const formatted = useComputed(() => test.formatItem(value.value));
 
   useLayoutEffect(() => {
     test.doit((v: number) => {
@@ -14,9 +13,17 @@ function App() {
     });
   }, [])
 
+  // reading `.value` during render subscribes the *component*, so a
+  // synchronous burst of writes coalesces into one re-render (the point of
+  // this bench). Binding the signal (or a computed) per <span> notifies
+  // 1k subscribers on every one of 10k writes, and even with the DOM flush
+  // microtask-batched that measured 170x slower at a tenth of this
+  // workload (36.8s vs 215ms, throttle x4) and never finished the full
+  // one. Each consumer formats the value itself, like every other
+  // framework's implementation.
   return <output>
     {test.consumerRange.map((c: number) => {
-      return <span key={c}>{formatted}</span>;
+      return <span key={c}>{test.formatItem(value.value)}</span>;
     })}
   </output>
 }

--- a/frameworks/preact/one-item-many-updates/src/App.tsx
+++ b/frameworks/preact/one-item-many-updates/src/App.tsx
@@ -1,12 +1,11 @@
 import { useLayoutEffect } from 'preact/hooks'
-import { useSignal, useComputed } from '@preact/signals'
+import { useSignal } from '@preact/signals'
 import { helpers } from 'common';
 
 const test = helpers.oneItem10kUpdates();
 
 function App() {
   const count = useSignal(test.getData());
-  const formatted = useComputed(() => test.formatItem(count.value));
 
   useLayoutEffect(() => {
     test.doit((i: number) => {
@@ -14,7 +13,13 @@ function App() {
     });
   }, [])
 
-  return <output>{formatted}</output>
+  // reading `.value` during render subscribes the *component*, so a
+  // synchronous run of updates coalesces into one re-render. Binding the
+  // signal as a text node measured 42.5s for the 100k sync bench vs 32ms
+  // this way (throttle x4); it only wins on the (async) variants, and
+  // mildly (500ms vs 672ms), because between-update yields let it write
+  // just the text node while this version re-renders the component
+  return <output>{test.formatItem(count.value)}</output>
 }
 
 export default App


### PR DESCRIPTION
Targets #81's branch. The review thread's open questions were empirical, so this measures instead of arguing (standalone marks-reader over each app's dist, same protocol as the runner).

## What the numbers say (throttle x4 unless noted)

| bench | component subscription (main) | per-binding signals (#81) |
| --- | --- | --- |
| fan-out, 1k consumers × 1k updates, burst=100 | 215 ms | 36,770 ms |
| fan-out, full bench (10k updates) | 1,025 ms | no `:done` after 90 s |
| one-item, 100k sync | 32 ms | 42,509 ms |
| one-item, 100k async | 672 ms | 500 ms |
| one-item, 1k async | 37 ms | 22.5 ms |
| dbmon FPS (throttle x8, same-session A/B) | 13.2–14.8 | **19–20** |

The comment #81 deleted as wrong was right: per-`<span>` binding notifies every subscriber on every synchronous write, and the microtask-batched DOM flush doesn't save it — the fan-out bench would go from ~1 s to minutes, and one-item 100k sync from 32 ms to 42 s. The bindings only win on the `(async)` variants, mildly, where between-update yields let them skip component re-renders. CI didn't catch this because the Playwright workloads are shrunk (50 consumers × 500 updates runs in 62 ms).

## Changes

- **fan-out, one-item-many-updates**: back to main's component-subscription implementations. They already keep all state in the component via `useSignal` (the review's requirement for the upcoming reactive `getData()`), and the restored comments now carry the measured numbers so this doesn't get "fixed" again.
- **dbmon-with-chat**: fine-grained is the real win here and stays — one `Signal<DBRow>` per row, `For` for rows/chats/query cells, only changed text nodes update. Reworked from #81's version:
  - all state lives in the component (`useSignal` + a `useMemo` lookup map), consistent with every other implementation, instead of module-level signals;
  - growing the row list is one `concat` per worker message inside the existing `batch()`, instead of `[...dbRows.value, row]` per new row (O(n²) on the first full payload).

## Testing

- `SKIP_BUILD=1 pnpm test --grep preact` — 5 passed (one dev-server flake auto-retried)
- `CONFORMANCE=1 SKIP_BUILD=1 pnpm test specs/conformance.spec.ts --grep preact` — 4 passed
- oxlint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)