### PR TITLE
Borrow a column from another result set on the table and boxplot pages

### DIFF
--- a/results/app/components/borrow-picker.gts
+++ b/results/app/components/borrow-picker.gts
@@ -1,0 +1,124 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { experiments, runs } from "virtual:result-sets";
+
+import { nameOf } from "#frameworks";
+import { formatRunName, titleOf } from "#utils";
+
+import type RouterService from "@ember/routing/router-service";
+import type { Borrowed } from "#routes/results.ts";
+import type { ResultSet } from "#types";
+
+export interface Borrow {
+  name: string;
+  data: ResultSet;
+  framework: string;
+}
+
+export function borrowOf(
+  router: RouterService,
+  borrowed: Borrowed | undefined,
+): Borrow | undefined {
+  if (!borrowed) return;
+
+  const available = borrowed.data.selections.frameworks;
+  const requested = router.currentRoute?.queryParams["col"];
+  const framework =
+    typeof requested === "string" && available.includes(requested) ? requested : available[0];
+
+  if (!framework) return;
+
+  return { name: borrowed.name, data: borrowed.data, framework };
+}
+
+export class BorrowPicker extends Component<{
+  borrowed: Borrowed | undefined;
+}> {
+  @service declare router: RouterService;
+
+  get current() {
+    const q = this.router.currentRoute?.queryParams["q"];
+
+    return typeof q === "string" ? q : "";
+  }
+
+  get runOptions() {
+    return runs.filter((name) => name !== this.current);
+  }
+
+  get experimentOptions() {
+    return experiments.filter((name) => name !== this.current);
+  }
+
+  get framework() {
+    return borrowOf(this.router, this.args.borrowed)?.framework ?? "";
+  }
+
+  get isNone() {
+    return !this.args.borrowed;
+  }
+
+  isSource = (name: string) => this.args.borrowed?.name === name;
+
+  isFramework = (name: string) => this.framework === name;
+
+  setSource = (event: Event) => {
+    const { value } = event.target as HTMLSelectElement;
+
+    this.router.transitionTo({ queryParams: { from: value || null, col: null } });
+  };
+
+  setFramework = (event: Event) => {
+    const { value } = event.target as HTMLSelectElement;
+
+    this.router.transitionTo({ queryParams: { col: value } });
+  };
+
+  remove = () => {
+    this.router.transitionTo({ queryParams: { from: null, col: null } });
+  };
+
+  <template>
+    <fieldset class="borrow-controls">
+      <legend>borrow a column</legend>
+      <label>
+        from run
+        <select name="borrow-from" {{on "change" this.setSource}}>
+          <option value="" selected={{this.isNone}}>none</option>
+          <optgroup label="Runs">
+            {{#each this.runOptions as |name|}}
+              <option
+                value={{name}}
+                selected={{this.isSource name}}
+                title={{titleOf name}}
+              >{{formatRunName name}}</option>
+            {{/each}}
+          </optgroup>
+          {{#if this.experimentOptions.length}}
+            <optgroup label="Experiments">
+              {{#each this.experimentOptions as |name|}}
+                <option
+                  value={{name}}
+                  selected={{this.isSource name}}
+                  title={{titleOf name}}
+                >{{formatRunName name}}</option>
+              {{/each}}
+            </optgroup>
+          {{/if}}
+        </select>
+      </label>
+      {{#if @borrowed}}
+        <label>
+          framework
+          <select name="borrow-framework" {{on "change" this.setFramework}}>
+            {{#each @borrowed.data.selections.frameworks as |name|}}
+              <option value={{name}} selected={{this.isFramework name}}>{{nameOf name}}</option>
+            {{/each}}
+          </select>
+        </label>
+        <button type="button" {{on "click" this.remove}}>remove</button>
+      {{/if}}
+    </fieldset>
+  </template>
+}

--- a/results/app/components/settings.gts
+++ b/results/app/components/settings.gts
@@ -1,0 +1,39 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { DEFAULT_PERCENTILE } from "#utils";
+
+import type Owner from "@ember/owner";
+import type RouterService from "@ember/routing/router-service";
+
+function hasNonDefaults(router: RouterService) {
+  const qps = router.currentRoute?.queryParams ?? {};
+
+  if (qps["from"]) return true;
+  if (qps["mode"] !== undefined && qps["mode"] !== "raw") return true;
+  if (qps["p"] !== undefined && qps["p"] !== String(DEFAULT_PERCENTILE)) return true;
+
+  return false;
+}
+
+export class Settings extends Component<{
+  Blocks: { default: [] };
+}> {
+  @service declare router: RouterService;
+
+  open: boolean;
+
+  constructor(owner: Owner, args: object) {
+    super(owner, args);
+    this.open = hasNonDefaults(this.router);
+  }
+
+  <template>
+    <details class="settings" open={{this.open}}>
+      <summary>settings</summary>
+      <div class="fields">
+        {{yield}}
+      </div>
+    </details>
+  </template>
+}

--- a/results/app/routes/compare.ts
+++ b/results/app/routes/compare.ts
@@ -1,9 +1,9 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-import { experiments, runs } from "virtual:result-sets";
+import { runs } from "virtual:result-sets";
 
-import { warnOnVersionDivergence } from "#utils";
+import { fetchResultSet } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
 import type Transition from "@ember/routing/transition";
@@ -104,18 +104,4 @@ function runsFor(a: string | undefined, b: string | undefined) {
 
   // no runs named at all -- the two most recent
   return { a: runs[1] ?? runs[0], b: runs[0] };
-}
-
-async function fetchResultSet(name: string): Promise<ResultSet> {
-  // experiments live in a separate directory from the official runs
-  const dir = experiments.includes(name) ? "experiments" : "results";
-  const response = await fetch(`/${dir}/${name}.json`);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const json = await response.json();
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  warnOnVersionDivergence(json);
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return json;
 }

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -1,9 +1,7 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-import { experiments } from "virtual:result-sets";
-
-import { warnOnVersionDivergence } from "#utils";
+import { fetchResultSet } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
 import type Transition from "@ember/routing/transition";
@@ -11,10 +9,17 @@ import type { ResultSet } from "#types";
 
 interface Params {
   q: string;
+  from?: string;
+}
+
+export interface Borrowed {
+  name: string;
+  data: ResultSet;
 }
 
 export interface Model {
   data: ResultSet;
+  borrowed?: Borrowed;
 }
 
 export default class Results extends Route<Model> {
@@ -22,6 +27,10 @@ export default class Results extends Route<Model> {
 
   queryParams = {
     q: { refreshModel: true },
+    from: { refreshModel: true },
+    // which of the borrowed set's frameworks; the set is already loaded,
+    // so no model impact
+    col: {},
     // display mode for the tables page (raw | linear | log); no model impact
     mode: {},
     // which percentile of each run's samples to show (50 | 75 | 90);
@@ -48,20 +57,18 @@ export default class Results extends Route<Model> {
   // @ts-ignore
   async model(params: Record<string, string>): Promise<Model> {
     // SAFETY: verified in beforeModel
-    const { q } = params as unknown as Params;
+    const { q, from } = params as unknown as Params;
 
     try {
-      // experiments live in a separate directory from the official runs
-      const dir = experiments.includes(q) ? "experiments" : "results";
-      const response = await fetch(`/${dir}/${q}.json`);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const json = await response.json();
+      const [data, borrowedData] = await Promise.all([
+        fetchResultSet(q),
+        from ? fetchResultSet(from) : undefined,
+      ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      warnOnVersionDivergence(json);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      return { data: json };
+      return {
+        data,
+        borrowed: from && borrowedData ? { name: from, data: borrowedData } : undefined,
+      };
     } catch (e) {
       console.error(e);
       // SAFETY: don't care -- the fact that people can throw non-errors is a mistake

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -256,6 +256,31 @@ table {
     filter: contrast(0.4);
     mix-blend-mode: difference;
   }
+
+  th.borrowed,
+  td.borrowed {
+    border-inline-start: 1px dashed color-mix(in oklch, currentColor 35%, transparent);
+  }
+
+  .borrow-tag {
+    font-size: 0.7rem;
+    border: 1px solid currentColor;
+    border-radius: 0.25rem;
+    padding: 0 0.25rem;
+    opacity: 0.7;
+  }
+
+  .borrow-source {
+    display: block;
+    font-weight: normal;
+    opacity: 0.75;
+  }
+
+  .throttle-mismatch {
+    display: block;
+    font-weight: normal;
+    color: darkorange;
+  }
 }
 
 .compare-title {
@@ -338,7 +363,8 @@ table {
 /* The control bars above the tables: which value to show on a results
    table, which framework and runs to line up on the compare page. */
 .value-mode,
-.compare-controls {
+.compare-controls,
+.borrow-controls {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -401,7 +427,8 @@ table {
   }
 }
 
-.compare-controls select {
+.compare-controls select,
+.borrow-controls select {
   max-width: 40vw;
 }
 

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -360,6 +360,36 @@ table {
   }
 }
 
+.settings {
+  justify-self: center;
+  text-align: center;
+
+  summary {
+    display: inline-block;
+    cursor: pointer;
+    padding: 0.25rem 1rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    opacity: 0.7;
+    border: 1px solid color-mix(in oklch, currentColor 25%, transparent);
+    border-radius: 0.5rem;
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+      border-color: color-mix(in oklch, currentColor 60%, transparent);
+    }
+  }
+
+  .fields {
+    display: grid;
+    justify-items: center;
+    padding-top: 1rem;
+    text-align: initial;
+  }
+}
+
 /* The control bars above the tables: which value to show on a results
    table, which framework and runs to line up on the compare page. */
 .value-mode,

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -365,7 +365,9 @@ table {
   text-align: center;
 
   summary {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
     cursor: pointer;
     padding: 0.25rem 1rem;
     font-size: 0.7rem;
@@ -375,11 +377,22 @@ table {
     border: 1px solid color-mix(in oklch, currentColor 25%, transparent);
     border-radius: 0.5rem;
 
+    &::before {
+      content: "";
+      border-block: 0.3em solid transparent;
+      border-inline-start: 0.42em solid color-mix(in oklch, currentColor 70%, transparent);
+      transition: rotate 0.15s;
+    }
+
     &:hover,
     &:focus-visible {
       opacity: 1;
       border-color: color-mix(in oklch, currentColor 60%, transparent);
     }
+  }
+
+  &[open] summary::before {
+    rotate: 90deg;
   }
 
   .fields {

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -7,6 +7,7 @@ import { converter, filterBrightness, formatCss } from "culori";
 import { modifier } from "ember-modifier";
 
 import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
+import { Settings } from "#components/settings.gts";
 import { frameworks } from "#frameworks";
 import { formatRunName, samplesOf } from "#utils";
 
@@ -176,7 +177,9 @@ export default class Boxplat extends Component<{
   }
 
   <template>
-    <BorrowPicker @borrowed={{@model.borrowed}} />
+    <Settings>
+      <BorrowPicker @borrowed={{@model.borrowed}} />
+    </Settings>
 
     {{#each this.benchmarkInfo as |benchInfo|}}
       <section>

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -1,13 +1,17 @@
 import Component from "@glimmer/component";
+import { service } from "@ember/service";
 
 // https://github.com/sgratzl/chartjs-chart-boxplot
 import { BoxPlotChart } from "@sgratzl/chartjs-chart-boxplot";
 import { converter, filterBrightness, formatCss } from "culori";
 import { modifier } from "ember-modifier";
 
+import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { frameworks } from "#frameworks";
-import { samplesOf } from "#utils";
+import { formatRunName, samplesOf } from "#utils";
 
+import type RouterService from "@ember/routing/router-service";
+import type { Borrow } from "#components/borrow-picker.gts";
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
 
@@ -15,10 +19,10 @@ const HSL = converter("hsl");
 const BRIGHTEN = filterBrightness(1.5, "lrgb");
 const DARKEN = filterBrightness(0.5, "lrgb");
 
-function boxData(file: ResultSet, benchInfo: BenchmarkInfo) {
+function boxData(file: ResultSet, benchInfo: BenchmarkInfo, borrow: Borrow | undefined) {
   // Why is chartjs like this?
   // managing this many arrays in sync across indicies is annoying
-  const labels: string[] = [];
+  const labels: Array<string | string[]> = [];
   const data: number[][] = [];
   const backgroundColor: string[] = [];
   const borderColor: string[] = [];
@@ -26,10 +30,10 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo) {
   const medianColor: string[] = [];
   const lowerBackgroundColor: string[] = [];
 
-  for (const framework of file.selections.frameworks) {
-    labels.push(framework);
+  const add = (label: string | string[], source: ResultSet, framework: string) => {
+    labels.push(label);
 
-    const marks = file.results[framework]?.[benchInfo.name]?.times;
+    const marks = source.results[framework]?.[benchInfo.name]?.times;
 
     data.push(marks ? samplesOf(marks, benchInfo.measure) : []);
 
@@ -51,6 +55,14 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo) {
     // meanBackgroundColor
 
     lowerBackgroundColor.push(brighter);
+  };
+
+  for (const framework of file.selections.frameworks) {
+    add(framework, file, framework);
+  }
+
+  if (borrow) {
+    add([borrow.framework, `from ${formatRunName(borrow.name)}`], borrow.data, borrow.framework);
   }
 
   const datasets = [
@@ -73,9 +85,9 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo) {
 
 const renderChart = modifier(function boxplot(
   element: HTMLCanvasElement,
-  [file, benchInfo]: [ResultSet, BenchmarkInfo],
+  [file, benchInfo, borrow]: [ResultSet, BenchmarkInfo, Borrow | undefined],
 ) {
-  const { datasets, labels } = boxData(file, benchInfo);
+  const { datasets, labels } = boxData(file, benchInfo, borrow);
   // https://www.sgratzl.com/chartjs-chart-boxplot/examples/styling.html
   const chart = new BoxPlotChart(element, {
     data: {
@@ -139,6 +151,8 @@ const renderChart = modifier(function boxplot(
 export default class Boxplat extends Component<{
   model: Model;
 }> {
+  @service declare router: RouterService;
+
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo
       .toSorted()
@@ -149,11 +163,21 @@ export default class Boxplat extends Component<{
     return this.args.model.data.selections.frameworks;
   }
 
+  get borrow() {
+    return borrowOf(this.router, this.args.model.borrowed);
+  }
+
+  get rows() {
+    return this.frameworks.length + (this.borrow ? 1 : 0);
+  }
+
   get height() {
-    return 70 * this.frameworks.length;
+    return 70 * this.rows;
   }
 
   <template>
+    <BorrowPicker @borrowed={{@model.borrowed}} />
+
     {{#each this.benchmarkInfo as |benchInfo|}}
       <section>
         <header class="boxplot-header">
@@ -173,7 +197,7 @@ export default class Boxplat extends Component<{
         {{! chart.js responsive sizing tracks the parent element,
             so the fixed height goes on a wrapper, not the canvas }}
         <div style="position: relative; height:{{this.height}}px;">
-          <canvas {{renderChart @model.data benchInfo}}></canvas>
+          <canvas {{renderChart @model.data benchInfo this.borrow}}></canvas>
         </div>
       </section>
     {{/each}}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -6,23 +6,29 @@ import { service } from "@ember/service";
 import { interpolate } from "culori";
 
 import { BenchmarkName } from "#components/benchmark-name.gts";
+import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
+  formatRunName,
   higherIsBetterBenches,
+  isoOf,
   labelFor,
   lowerIsBetterBenches,
   overrideOf,
   percentileFrom,
   PERCENTILES,
   round,
+  throttleLabel,
   timeFor,
+  titleOf,
   variantOf,
   versionOf,
 } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
+import type { Borrow } from "#components/borrow-picker.gts";
 import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
 import type { Percentile } from "#utils";
@@ -116,6 +122,7 @@ class TableRow extends Component<{
   file: ResultSet;
   benchInfo: BenchmarkInfo;
   frameworkNames: string[];
+  borrow: Borrow | undefined;
 }> {
   @service declare router: RouterService;
 
@@ -132,27 +139,37 @@ class TableRow extends Component<{
       percentileFrom(this.router),
     );
 
+    const { borrow } = this.args;
+    const borrowedSpeed = borrow
+      ? timeFor(borrow.data, borrow.framework, this.args.benchInfo, percentileFrom(this.router))
+      : undefined;
+
+    let lo = min;
+    let hi = max;
+
+    if (borrowedSpeed !== undefined) {
+      if (borrowedSpeed < lo) lo = borrowedSpeed;
+      if (borrowedSpeed > hi) hi = borrowedSpeed;
+    }
+
+    const reverse = this.args.benchInfo.whatsBetter === "bigger";
     const colors: Record<string, string | undefined> = {};
 
     for (const framework of this.args.frameworkNames) {
-      colors[framework] = colorFor(
-        speeds[framework],
-        min,
-        max,
-        this.args.benchInfo.whatsBetter === "bigger",
-      );
+      colors[framework] = colorFor(speeds[framework], lo, hi, reverse);
     }
 
-    return { speeds, min, max, colors };
+    const borrowedColor = colorFor(borrowedSpeed, lo, hi, reverse);
+
+    return { speeds, min: lo, max: hi, colors, borrowedSpeed, borrowedColor };
   }
 
   get colors() {
     return this.row.colors;
   }
 
-  value = (framework: string) => {
-    const { speeds, min, max } = this.row;
-    const speed = speeds[framework];
+  displayOf = (speed: number | undefined) => {
+    const { min, max } = this.row;
     const bestIsMax = this.args.benchInfo.whatsBetter === "bigger";
 
     switch (modeFrom(this.router)) {
@@ -169,6 +186,12 @@ class TableRow extends Component<{
     }
   };
 
+  value = (framework: string) => this.displayOf(this.row.speeds[framework]);
+
+  get borrowedValue() {
+    return this.displayOf(this.row.borrowedSpeed);
+  }
+
   <template>
     <tr>
       <BenchmarkName @bench={{@benchInfo}} />
@@ -178,6 +201,12 @@ class TableRow extends Component<{
               framework
             }}</span></td>
       {{/each}}
+
+      {{#if @borrow}}
+        <td class="borrowed" style="background: {{this.row.borrowedColor}};"><span
+            class="value"
+          >{{this.borrowedValue}}</span></td>
+      {{/if}}
     </tr>
   </template>
 }
@@ -185,6 +214,7 @@ class TableRow extends Component<{
 class Table extends Component<{
   benches: BenchmarkInfo[];
   file: ResultSet;
+  borrow: Borrow | undefined;
 }> {
   @service declare router: RouterService;
 
@@ -222,6 +252,20 @@ class Table extends Component<{
       }
     }
 
+    const { borrow } = this.args;
+
+    if (borrow) {
+      totals.borrowed = 0;
+
+      for (const bench of this.args.benches) {
+        const time = timeFor(borrow.data, borrow.framework, bench, this.percentile);
+
+        if (time === undefined) continue;
+
+        totals.borrowed += time;
+      }
+    }
+
     let max = -Infinity;
     let min = Infinity;
 
@@ -240,6 +284,18 @@ class Table extends Component<{
 
   get frameworkNames() {
     return this.args.file.selections.frameworks;
+  }
+
+  get borrowedThrottle() {
+    const { borrow, file } = this.args;
+
+    if (!borrow) return;
+
+    const theirs = borrow.data.args?.CPU_THROTTLE;
+
+    if ((theirs ?? null) === (file.args?.CPU_THROTTLE ?? null)) return;
+
+    return throttleLabel(theirs);
   }
 
   totalValue = (framework: string) => {
@@ -288,11 +344,37 @@ class Table extends Component<{
               </span>
             </th>
           {{/each}}
+
+          {{#if @borrow}}
+            <th class="fw-header borrowed">
+              <span class="borrow-tag">borrowed</span>
+              <FrameworkInfo @name={{@borrow.framework}} />
+              <Variant @variant={{variantOf @borrow.data @borrow.framework}} />
+              <span class="small">
+                <Version
+                  @version={{versionOf @borrow.data @borrow.framework}}
+                  @override={{overrideOf @borrow.data @borrow.framework}}
+                />
+              </span>
+              <span class="borrow-source small" title={{titleOf @borrow.name}}>
+                from
+                <time datetime={{isoOf @borrow.name}}>{{formatRunName @borrow.name}}</time>
+              </span>
+              {{#if this.borrowedThrottle}}
+                <span class="small throttle-mismatch">{{this.borrowedThrottle}}</span>
+              {{/if}}
+            </th>
+          {{/if}}
         </tr>
       </thead>
       <tbody>
         {{#each @benches as |bench|}}
-          <TableRow @file={{@file}} @benchInfo={{bench}} @frameworkNames={{this.frameworkNames}} />
+          <TableRow
+            @file={{@file}}
+            @benchInfo={{bench}}
+            @frameworkNames={{this.frameworkNames}}
+            @borrow={{@borrow}}
+          />
         {{/each}}
       </tbody>
 
@@ -310,6 +392,19 @@ class Table extends Component<{
                 <span class="value">{{this.totalValue framework}}</span>
               </td>
             {{/each}}
+
+            {{#if @borrow}}
+              <td
+                class="borrowed"
+                style="background: {{colorFor
+                  this.totals.borrowed
+                  this.totals.min
+                  this.totals.max
+                }}"
+              >
+                <span class="value">{{this.totalValue "borrowed"}}</span>
+              </td>
+            {{/if}}
           </tr>
         </tfoot>
       {{/if}}
@@ -348,6 +443,10 @@ export default class ResultsTables extends Component<{
 
   get file() {
     return this.args.model.data;
+  }
+
+  get borrow() {
+    return borrowOf(this.router, this.args.model.borrowed);
   }
 
   get benchmarkInfo() {
@@ -416,10 +515,12 @@ export default class ResultsTables extends Component<{
       <span class="units">of each run's samples</span>
     </fieldset>
 
+    <BorrowPicker @borrowed={{@model.borrowed}} />
+
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>
 
-      <Table @benches={{this.higherBenches}} @file={{this.file}} />
+      <Table @benches={{this.higherBenches}} @file={{this.file}} @borrow={{this.borrow}} />
       <br />
       <br />
       <br />
@@ -428,7 +529,7 @@ export default class ResultsTables extends Component<{
     {{#if this.lowerBenches.length}}
       <h2>lower is better</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} />
+      <Table @benches={{this.lowerBenches}} @file={{this.file}} @borrow={{this.borrow}} />
       <br />
       <br />
       <br />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -8,6 +8,7 @@ import { interpolate } from "culori";
 import { BenchmarkName } from "#components/benchmark-name.gts";
 import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { Settings } from "#components/settings.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
@@ -464,58 +465,60 @@ export default class ResultsTables extends Component<{
   }
 
   <template>
-    <fieldset class="value-mode">
-      <legend>values</legend>
-      <label>
-        <input
-          type="radio"
-          name="value-mode"
-          checked={{this.isMode "raw"}}
-          {{on "change" (fn this.setMode "raw")}}
-        />
-        raw
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="value-mode"
-          checked={{this.isMode "linear"}}
-          {{on "change" (fn this.setMode "linear")}}
-        />
-        score
-        <span class="units">(normalized 0 to 1)</span>
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="value-mode"
-          checked={{this.isMode "times"}}
-          {{on "change" (fn this.setMode "times")}}
-        />
-        times best
-        <span class="units">(1x is best)</span>
-      </label>
-    </fieldset>
-
-    <fieldset class="value-mode">
-      <legend>statistic</legend>
-      {{#each this.percentiles as |percentile|}}
+    <Settings>
+      <fieldset class="value-mode">
+        <legend>values</legend>
         <label>
           <input
             type="radio"
-            name="percentile"
-            checked={{this.isPercentile percentile}}
-            {{on "change" (fn this.setPercentile percentile)}}
+            name="value-mode"
+            checked={{this.isMode "raw"}}
+            {{on "change" (fn this.setMode "raw")}}
           />
-          {{this.labelFor percentile}}
+          raw
         </label>
-      {{/each}}
-      {{! percentiles run toward the worse end either way, so the same
-          number means the same thing on both tables }}
-      <span class="units">of each run's samples</span>
-    </fieldset>
+        <label>
+          <input
+            type="radio"
+            name="value-mode"
+            checked={{this.isMode "linear"}}
+            {{on "change" (fn this.setMode "linear")}}
+          />
+          score
+          <span class="units">(normalized 0 to 1)</span>
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="value-mode"
+            checked={{this.isMode "times"}}
+            {{on "change" (fn this.setMode "times")}}
+          />
+          times best
+          <span class="units">(1x is best)</span>
+        </label>
+      </fieldset>
 
-    <BorrowPicker @borrowed={{@model.borrowed}} />
+      <fieldset class="value-mode">
+        <legend>statistic</legend>
+        {{#each this.percentiles as |percentile|}}
+          <label>
+            <input
+              type="radio"
+              name="percentile"
+              checked={{this.isPercentile percentile}}
+              {{on "change" (fn this.setPercentile percentile)}}
+            />
+            {{this.labelFor percentile}}
+          </label>
+        {{/each}}
+        {{! percentiles run toward the worse end either way, so the same
+          number means the same thing on both tables }}
+        <span class="units">of each run's samples</span>
+      </fieldset>
+
+      <BorrowPicker @borrowed={{@model.borrowed}} />
+    </Settings>
 
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -1,6 +1,6 @@
 import { assert, warn } from "@ember/debug";
 
-import { metadata } from "virtual:result-sets";
+import { experiments, metadata } from "virtual:result-sets";
 
 import { frameworks } from "./frameworks.ts";
 
@@ -40,6 +40,20 @@ export function warnOnVersionDivergence(file: ResultSet) {
       },
     );
   }
+}
+
+export async function fetchResultSet(name: string): Promise<ResultSet> {
+  // experiments live in a separate directory from the official runs
+  const dir = experiments.includes(name) ? "experiments" : "results";
+  const response = await fetch(`/${dir}/${name}.json`);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const json = await response.json();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  warnOnVersionDivergence(json);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return json;
 }
 
 /**


### PR DESCRIPTION
Adds a "borrow a column" control to the Table and Boxplot pages: pick another run (or experiment) and one of its frameworks, and that framework's results appear alongside the current set's, clearly marked as coming from elsewhere.

## UX

- A `borrow a column` fieldset (matching the existing control-bar styling) sits with the other controls on both pages. Its `from run` select lists every other run and experiment by display name (grouped, current set excluded, `none` default). Once a source is picked, a `framework` select (populated from that set's frameworks) and a `remove` button appear.
- The choice is held in `from` / `col` query params (route-declared, `from` refreshes the model), so URLs are shareable and reload cleanly. Nothing is fetched until a source is picked; the source set loads through the same `fetchResultSet` path the compare route uses (now shared via `#utils`).
- `col` defaults to the source set's first framework and falls back gracefully when invalid; benches the source doesn't have simply render empty cells / empty boxes.

## How the borrowed column is labeled

- **Table**: the column is set off by a dashed hairline and headed by a bordered `borrowed` tag, the framework's logo/name/variant/version *from the source set*, and `from <run display name>` (e.g. `from #5 Chrome 143 - 120 Hz - 4x throttle - Jul 29, 2026`, with the raw name kept in the `<time>`/`title` attributes). When the source run's CPU throttle differs from the viewed run's, its throttle is called out in orange, mirroring the compare page's mismatch treatment. Borrowed values participate in each row's min/max, so cell colors, scores, and times-best read across both sets; the borrowed total joins the totals row.
- **Boxplot**: every chart gains one extra box whose axis label is two lines: the framework name, then `from <run display name>`.

## Verification

- `pnpm lint` (results app and repo root) and `pnpm build` are green.
- Exercised end-to-end in the browser at 1920px on both pages: picking a set + framework, header/label origin text, QP round-trip via hard reload, `remove` clearing both params, borrowing from the shrunken single-framework experiment sets, sticky thead/benchmark-name columns still pinning, page-level horizontal scroll intact, and the compare route unaffected by the `fetchResultSet` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)