### PR TITLE
FPS audit: the x4 numbers are a vsync ceiling, not a calculation bug — warn when pinned at the cap, default scripts to x8

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "use-tar-for": "node --experimental-strip-types ./src/runner/use-tar-for.ts",
     "bench": "node --experimental-strip-types ./src/runner/index.ts",
     "bench:add": "node --experimental-strip-types ./src/runner/add.ts",
-    "bench:one": "pnpm bench --bench=all --cpu-throttle=4",
-    "bench:all": "pnpm bench --framework=all --bench=all --cpu-throttle=4"
+    "bench:one": "pnpm bench --bench=all --cpu-throttle=8",
+    "bench:all": "pnpm bench --framework=all --bench=all --cpu-throttle=8"
   },
   "packageManager": "pnpm@10.21.0",
   "engines": {

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -10,10 +10,13 @@ import { getBenchInfo } from './bench-info.ts';
 import { chromeLocation } from './environment.ts';
 import {
   addResult,
+  info as environmentInfo,
   prepareForResults as prepareForResults,
   saveTiming,
 } from './results.ts';
 import { serve } from './serve.ts';
+
+import type { BenchmarkInfo } from './bench-info.ts';
 
 const info = await getBenchInfo();
 
@@ -33,6 +36,39 @@ interface MarkEntry {
    * (in the case of the dbmon test, this could be the FPS (for example))
    */
   detail?: unknown;
+}
+
+const frameCap = HEADLESS ? 60 : environmentInfo.environment.monitor.hz;
+
+function warnIfCapped(
+  framework: string,
+  bench: BenchmarkInfo,
+  marks: MarkEntry[],
+) {
+  if (bench.measure !== 'fps') return;
+  if (!frameCap) return;
+
+  const samples: number[] = [];
+
+  for (const mark of marks) {
+    if (mark.name === bench.measure && typeof mark.detail === 'number') {
+      samples.push(mark.detail);
+    }
+  }
+
+  if (samples.length === 0) return;
+
+  const sorted = samples.slice().sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)]!;
+
+  if (median < frameCap * 0.95) return;
+
+  clack.log.warn(
+    `${framework}: "${bench.name}" is pinned at the ${frameCap}hz frame cap ` +
+      `(median ${median.toFixed(1)} FPS). The page kept up with every frame at ` +
+      `--cpu-throttle=${CPU_THROTTLE}, so this sample records the display's ceiling, ` +
+      `not the framework's limit. Increase --cpu-throttle until frameworks fall below the cap.`,
+  );
 }
 
 async function getMarks(browser: Browser, url: string) {
@@ -252,6 +288,8 @@ for (const framework of info.frameworks) {
           clack.log.info(`\t\tRemaining: ${count - i}`);
 
           const performanceMarks = await getMarks(browser, url);
+
+          warnIfCapped(framework, bench, performanceMarks);
 
           const name = variant.name
             ? `${bench.name} ${variant.name}`


### PR DESCRIPTION
Investigates the suspicion that "on the 4x runs, all frameworks are close to max FPS" (so the FPS calculation looked untrustworthy). Conclusion: **the FPS calculation is correct — the x4 numbers are a genuine ceiling.** This PR adds a loud runner warning at the moment a sample is pinned at the cap, and moves the `bench:one` / `bench:all` convenience scripts from `--cpu-throttle=4` to `8`.

**No recorded number changes meaning.** The FPS math is untouched; the warning is additive and the throttle default only affects future runs (each result file records its own `CPU_THROTTLE`, so old files stay interpretable as-is).

## What the FPS number actually is

`common/src/fps.js` counts `requestAnimationFrame` callbacks and averages their timestamps over a 5s rolling window; `db-mon-with-chat.js` samples that average 5 times, every 5s. rAF fires at most once per display frame, so the number is hard-capped by the refresh rate: **119hz headed on the recording machine, 60hz headless.** A framework that meets every frame deadline reads exactly the cap, no matter how much headroom it has left.

## Why x4 compressed toward max

Mining the recorded result sets (dbmon p50 of the 5 samples per run):

| framework | x4 Jul 23 | x4 Jul 26 | x4 Jul 29 (f4) | x4 Jul 29 (f5) | x8 Jul 21 | x8 Jul 29 |
|---|---|---|---|---|---|---|
| angular | 118.7 | 119.8 | 119.4 | 119.8 | – | 70.3 |
| ember | 73.1 | 69.1 | 63.0 | 107.0 | 12.9 | 25.7 |
| react | 116.9 | 117.2 | 119.6 | 120.0 | 34.4 | 58.5 |
| solid | 72.6 | 83.3 | 115.6 | 119.4 | 19.7 | 61.7 |
| svelte | 118.7 | 119.2 | 119.0 | 120.0 | 40.8 | 71.2 |
| vue | 75.3 | 88.5 | 112.8 | 119.0 | 17.4 | 48.4 |

x4 *used to* discriminate. Between Jul 26 and Jul 29 the app-optimization PRs landed (Solid hot paths + Solid 2 beta, Vue Vapor, React Compiler + `useLayoutEffect`, the dbmon fine-grained rewrites) and pushed everything over the vsync line at x4 — while the same-day x8 run still separates the same builds cleanly (25.7 → 71.2). The apps got faster; the metric ran out of headroom.

## The calculation itself was verified honest

A headless probe (ember/vue/svelte × throttle 1/2/4/8/16) instrumented each page independently of `fps.js`: a second wall-clock rAF counter, a MutationObserver counting DOM writes, and a hook counting worker messages consumed.

- **The page's reported FPS matched the independent rAF counter at every throttle** (e.g. ember x4: 51.6 reported vs 50.8 counted; x8: 7.2 vs 7.2; x16: 5.8 vs 6.0). No inflation, no window trickery.
- **Pegged-at-cap is real work, not idle frames**: at the cap the page still consumed the workers' full offered load (~126 db messages/s, ~28k DOM character mutations per 5s bucket — identical at x1 and at the cap).
- Hypotheses checked and refuted: the rolling window does not let idle time "recover" the average (load is continuous; per-bucket values are stable, not sawtoothed); the sampling window does not exclude the heavy phase (samples span the whole 25s of continuous load); the workers do not slow down under throttle until far past saturation (offered load constant through x8, collapses only at x16).
- Headless curve shape (60 cap): everyone reads exactly 60.0 at x1/x2 → svelte still 60.0 at x4, vue 58.7, ember 51 → full spread at x8 (ember 7.2, vue 24, svelte 34.5) → compressed again at x16 (5.6–7.4, throughput collapse). FPS discriminates only in the band between the vsync ceiling and the saturation floor; x8 headed sits in that band today, x4 no longer does.

Two caveats worth knowing (findings, not code changes):

- **Headed and headless FPS are not comparable.** Same builds at x8: ember 25.7 headed vs 7.2 headless, vue 48.4 vs 24, svelte 71.2 vs 34.5. Ordering is preserved; magnitudes are not (different cap and much harsher frame pacing under load headless). The `--headless` flag's "limited to 60 fps" note undersells the difference.
- **A single dbmon page-load is noisy.** dbmon records one page-load per result set (`ignoreCount`), and back-to-back identical loads measured p50s of 9.4 / 10.4 / 7.2 / 7.2 / 7.2 (±45%) — which is also why ember read 63 at x4 in file 4 and 107 in file 5 on the same day with identical code. Worth keeping in mind before reading meaning into any lone dbmon delta.

## Changes

- `src/runner/index.ts`: after each sample of an FPS-measured bench, warn when the median sample is ≥95% of the frame cap (recorded monitor hz headed, 60 headless), naming the framework and telling the operator to raise `--cpu-throttle`. Verified live: a headless x1 ember run prints `ember: "DB Monitor w/ chat simulation" is pinned at the 60hz frame cap (median 60.0 FPS)...`.
- `package.json`: `bench:one` / `bench:all` now use `--cpu-throttle=8`. **Flagging loudly:** future default-script runs are at x8 and their absolute numbers will not line up with x4 result sets — but x4 was no longer measuring the fast frameworks at all, and the newest recorded set (file 6) is already an x8 run. Duration benches simply take proportionally longer; the full x8 suite has completed fine twice (files 1 and 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
