### PR TITLE
Hide frameworks from the table and boxplot views

### DIFF
--- a/results/app/components/framework-toggles.gts
+++ b/results/app/components/framework-toggles.gts
@@ -1,0 +1,53 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { nameOf } from "#frameworks";
+
+import type RouterService from "@ember/routing/router-service";
+import type { ResultSet } from "#types";
+
+export function hiddenFrameworksFrom(router: RouterService) {
+  const raw = router.currentRoute?.queryParams["hide"];
+
+  return typeof raw === "string" && raw.length > 0 ? raw.split(",") : [];
+}
+
+export function visibleFrameworksOf(router: RouterService, file: ResultSet) {
+  const hidden = hiddenFrameworksFrom(router);
+
+  return file.selections.frameworks.filter((name) => !hidden.includes(name));
+}
+
+export class FrameworkToggles extends Component<{
+  file: ResultSet;
+}> {
+  @service declare router: RouterService;
+
+  isShown = (name: string) => !hiddenFrameworksFrom(this.router).includes(name);
+
+  toggle = (name: string, event: Event) => {
+    const { checked } = event.target as HTMLInputElement;
+    const hidden = hiddenFrameworksFrom(this.router).filter((entry) => entry !== name);
+
+    if (!checked) hidden.push(name);
+
+    this.router.transitionTo({ queryParams: { hide: hidden.join(",") || null } });
+  };
+
+  <template>
+    <fieldset class="value-mode">
+      <legend>frameworks</legend>
+      {{#each @file.selections.frameworks as |name|}}
+        <label>
+          <input
+            type="checkbox"
+            name="show-{{name}}"
+            checked={{this.isShown name}}
+            {{on "change" (fn this.toggle name)}}
+          />
+          {{nameOf name}}
+        </label>
+      {{/each}}
+    </fieldset>
+  </template>
+}

--- a/results/app/components/settings.gts
+++ b/results/app/components/settings.gts
@@ -6,26 +6,32 @@ import { DEFAULT_PERCENTILE } from "#utils";
 import type Owner from "@ember/owner";
 import type RouterService from "@ember/routing/router-service";
 
-function hasNonDefaults(router: RouterService) {
+const DEFAULTS: Record<string, string> = {
+  mode: "raw",
+  p: String(DEFAULT_PERCENTILE),
+};
+
+function hasNonDefaults(router: RouterService, params: string[]) {
   const qps = router.currentRoute?.queryParams ?? {};
 
-  if (qps["from"]) return true;
-  if (qps["mode"] !== undefined && qps["mode"] !== "raw") return true;
-  if (qps["p"] !== undefined && qps["p"] !== String(DEFAULT_PERCENTILE)) return true;
+  return params.some((param) => {
+    const value = qps[param];
 
-  return false;
+    return value !== undefined && value !== "" && value !== DEFAULTS[param];
+  });
 }
 
 export class Settings extends Component<{
+  Args: { params: string[] };
   Blocks: { default: [] };
 }> {
   @service declare router: RouterService;
 
   open: boolean;
 
-  constructor(owner: Owner, args: object) {
+  constructor(owner: Owner, args: { params: string[] }) {
     super(owner, args);
-    this.open = hasNonDefaults(this.router);
+    this.open = hasNonDefaults(this.router, args.params);
   }
 
   <template>

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -31,6 +31,7 @@ export default class Results extends Route<Model> {
     // which of the borrowed set's frameworks; the set is already loaded,
     // so no model impact
     col: {},
+    hide: {},
     // display mode for the tables page (raw | linear | log); no model impact
     mode: {},
     // which percentile of each run's samples to show (50 | 75 | 90);

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -362,12 +362,10 @@ table {
 
 .settings {
   justify-self: center;
-  text-align: center;
 
   summary {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5em;
+    width: fit-content;
+    margin-inline: auto;
     cursor: pointer;
     padding: 0.25rem 1rem;
     font-size: 0.7rem;
@@ -377,13 +375,6 @@ table {
     border: 1px solid color-mix(in oklch, currentColor 25%, transparent);
     border-radius: 0.5rem;
 
-    &::before {
-      content: "";
-      border-block: 0.3em solid transparent;
-      border-inline-start: 0.42em solid color-mix(in oklch, currentColor 70%, transparent);
-      transition: rotate 0.15s;
-    }
-
     &:hover,
     &:focus-visible {
       opacity: 1;
@@ -391,15 +382,10 @@ table {
     }
   }
 
-  &[open] summary::before {
-    rotate: 90deg;
-  }
-
   .fields {
     display: grid;
     justify-items: center;
     padding-top: 1rem;
-    text-align: initial;
   }
 }
 

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -7,6 +7,7 @@ import { converter, filterBrightness, formatCss } from "culori";
 import { modifier } from "ember-modifier";
 
 import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
+import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
 import { frameworks } from "#frameworks";
 import { formatRunName, samplesOf } from "#utils";
@@ -20,7 +21,12 @@ const HSL = converter("hsl");
 const BRIGHTEN = filterBrightness(1.5, "lrgb");
 const DARKEN = filterBrightness(0.5, "lrgb");
 
-function boxData(file: ResultSet, benchInfo: BenchmarkInfo, borrow: Borrow | undefined) {
+function boxData(
+  file: ResultSet,
+  benchInfo: BenchmarkInfo,
+  frameworkNames: string[],
+  borrow: Borrow | undefined,
+) {
   // Why is chartjs like this?
   // managing this many arrays in sync across indicies is annoying
   const labels: Array<string | string[]> = [];
@@ -58,7 +64,7 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo, borrow: Borrow | und
     lowerBackgroundColor.push(brighter);
   };
 
-  for (const framework of file.selections.frameworks) {
+  for (const framework of frameworkNames) {
     add(framework, file, framework);
   }
 
@@ -86,9 +92,14 @@ function boxData(file: ResultSet, benchInfo: BenchmarkInfo, borrow: Borrow | und
 
 const renderChart = modifier(function boxplot(
   element: HTMLCanvasElement,
-  [file, benchInfo, borrow]: [ResultSet, BenchmarkInfo, Borrow | undefined],
+  [file, benchInfo, frameworkNames, borrow]: [
+    ResultSet,
+    BenchmarkInfo,
+    string[],
+    Borrow | undefined,
+  ],
 ) {
-  const { datasets, labels } = boxData(file, benchInfo, borrow);
+  const { datasets, labels } = boxData(file, benchInfo, frameworkNames, borrow);
   // https://www.sgratzl.com/chartjs-chart-boxplot/examples/styling.html
   const chart = new BoxPlotChart(element, {
     data: {
@@ -161,8 +172,10 @@ export default class Boxplat extends Component<{
   }
 
   get frameworks() {
-    return this.args.model.data.selections.frameworks;
+    return visibleFrameworksOf(this.router, this.args.model.data);
   }
+
+  settingParams = ["hide", "from"];
 
   get borrow() {
     return borrowOf(this.router, this.args.model.borrowed);
@@ -177,7 +190,9 @@ export default class Boxplat extends Component<{
   }
 
   <template>
-    <Settings>
+    <Settings @params={{this.settingParams}}>
+      <FrameworkToggles @file={{@model.data}} />
+
       <BorrowPicker @borrowed={{@model.borrowed}} />
     </Settings>
 
@@ -200,7 +215,7 @@ export default class Boxplat extends Component<{
         {{! chart.js responsive sizing tracks the parent element,
             so the fixed height goes on a wrapper, not the canvas }}
         <div style="position: relative; height:{{this.height}}px;">
-          <canvas {{renderChart @model.data benchInfo this.borrow}}></canvas>
+          <canvas {{renderChart @model.data benchInfo this.frameworks this.borrow}}></canvas>
         </div>
       </section>
     {{/each}}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -8,6 +8,7 @@ import { interpolate } from "culori";
 import { BenchmarkName } from "#components/benchmark-name.gts";
 import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
@@ -215,6 +216,7 @@ class TableRow extends Component<{
 class Table extends Component<{
   benches: BenchmarkInfo[];
   file: ResultSet;
+  frameworkNames: string[];
   borrow: Borrow | undefined;
 }> {
   @service declare router: RouterService;
@@ -242,7 +244,7 @@ class Table extends Component<{
     if (!this.shouldShowTotals) return totals;
 
     for (const bench of this.args.benches) {
-      for (const framework of this.args.file.selections.frameworks) {
+      for (const framework of this.args.frameworkNames) {
         totals[framework] ??= 0;
 
         const time = timeFor(this.args.file, framework, bench, this.percentile);
@@ -284,7 +286,7 @@ class Table extends Component<{
   }
 
   get frameworkNames() {
-    return this.args.file.selections.frameworks;
+    return this.args.frameworkNames;
   }
 
   get borrowedThrottle() {
@@ -450,6 +452,12 @@ export default class ResultsTables extends Component<{
     return borrowOf(this.router, this.args.model.borrowed);
   }
 
+  get visibleFrameworks() {
+    return visibleFrameworksOf(this.router, this.file);
+  }
+
+  settingParams = ["mode", "p", "hide", "from"];
+
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo;
   }
@@ -465,7 +473,7 @@ export default class ResultsTables extends Component<{
   }
 
   <template>
-    <Settings>
+    <Settings @params={{this.settingParams}}>
       <fieldset class="value-mode">
         <legend>values</legend>
         <label>
@@ -517,13 +525,20 @@ export default class ResultsTables extends Component<{
         <span class="units">of each run's samples</span>
       </fieldset>
 
+      <FrameworkToggles @file={{this.file}} />
+
       <BorrowPicker @borrowed={{@model.borrowed}} />
     </Settings>
 
     {{#if this.higherBenches.length}}
       <h2>higher is better</h2>
 
-      <Table @benches={{this.higherBenches}} @file={{this.file}} @borrow={{this.borrow}} />
+      <Table
+        @benches={{this.higherBenches}}
+        @file={{this.file}}
+        @frameworkNames={{this.visibleFrameworks}}
+        @borrow={{this.borrow}}
+      />
       <br />
       <br />
       <br />
@@ -532,7 +547,12 @@ export default class ResultsTables extends Component<{
     {{#if this.lowerBenches.length}}
       <h2>lower is better</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} @borrow={{this.borrow}} />
+      <Table
+        @benches={{this.lowerBenches}}
+        @file={{this.file}}
+        @frameworkNames={{this.visibleFrameworks}}
+        @borrow={{this.borrow}}
+      />
       <br />
       <br />
       <br />


### PR DESCRIPTION
Follow-ups to #87, three changes:

## Hide frameworks

A `frameworks` fieldset in the settings panel (both the table and boxplot pages, matching the other control bars' voice) shows a checkbox per framework in the run. Unchecking one hides it: its column drops out of both tables and its box drops out of every chart. The hidden set lives in a `?hide=` query param (comma-separated, e.g. `?hide=react,svelte`), route-declared with no model impact, so URLs share and reload cleanly; an empty set clears the param.

Row min/max coloring, score, times-best, and the totals row all recompute over only the visible frameworks — hiding an outlier rescales the comparison, which is the point. The borrowed column is orthogonal: it has its own `remove` and joins whatever is visible.

## Boxplot settings no longer open themselves for foreign params

Root cause of the boxplot panel appearing open by default: `?mode=` / `?p=` are sticky route params, so touching either on the table page carried them along to the boxplot page, whose panel counted them as "non-default settings" even though it hosts neither control. `Settings` now takes the list of params its host page actually renders controls for (`mode`/`p`/`hide`/`from` on the table, `hide`/`from` on the boxplot) and only auto-opens for those. Direct visits were already closed.

## Native details caret

The hand-drawn `::before` triangle and its `[open]` rotation are gone (net −14 lines in app.css). The summary is back to its UA default `display: list-item`, so the browser's own `disclosure-closed` / `disclosure-open` marker does the job; the pill keeps its size via `width: fit-content; margin-inline: auto`.

## Verification

- 1920px on both pages: hide/show round-trips through URL reload (checkboxes, columns, and boxes all match the `?hide=` param), settings closed by default with the native caret on both pages, sticky-`?p=` table→boxplot navigation leaves the boxplot panel closed, hide + borrow together render correctly.
- `pnpm lint` (results + repo root) and `pnpm build` green; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)