### PR TITLE
Add a sort-by-total setting to the table and boxplot views

### DIFF
--- a/results/app/components/sort-control.gts
+++ b/results/app/components/sort-control.gts
@@ -1,0 +1,51 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { totalSortFrom } from "#utils";
+
+import type RouterService from "@ember/routing/router-service";
+import type { TotalSort } from "#utils";
+
+export class SortControl extends Component {
+  @service declare router: RouterService;
+
+  isSort = (sort: TotalSort | undefined) => totalSortFrom(this.router) === sort;
+
+  setSort = (sort: TotalSort | null) => {
+    this.router.transitionTo({ queryParams: { sort } });
+  };
+
+  <template>
+    <fieldset class="value-mode">
+      <legend>sort</legend>
+      <label>
+        <input
+          type="radio"
+          name="total-sort"
+          checked={{this.isSort undefined}}
+          {{on "change" (fn this.setSort null)}}
+        />
+        default order
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="total-sort"
+          checked={{this.isSort "best"}}
+          {{on "change" (fn this.setSort "best")}}
+        />
+        best total first
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="total-sort"
+          checked={{this.isSort "worst"}}
+          {{on "change" (fn this.setSort "worst")}}
+        />
+        worst total first
+      </label>
+      <span class="units">within each result area</span>
+    </fieldset>
+  </template>
+}

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -32,6 +32,8 @@ export default class Results extends Route<Model> {
     // so no model impact
     col: {},
     hide: {},
+    // order frameworks by their per-area totals (best | worst); no model impact
+    sort: {},
     // display mode for the tables page (raw | linear | log); no model impact
     mode: {},
     // which percentile of each run's samples to show (50 | 75 | 90);

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
 
 // https://github.com/sgratzl/chartjs-chart-boxplot
@@ -9,8 +10,17 @@ import { modifier } from "ember-modifier";
 import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
+import { SortControl } from "#components/sort-control.gts";
 import { frameworks } from "#frameworks";
-import { formatRunName, samplesOf } from "#utils";
+import {
+  formatRunName,
+  higherIsBetterBenches,
+  lowerIsBetterBenches,
+  percentileFrom,
+  samplesOf,
+  sortedByTotal,
+  totalSortFrom,
+} from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
 import type { Borrow } from "#components/borrow-picker.gts";
@@ -175,7 +185,34 @@ export default class Boxplat extends Component<{
     return visibleFrameworksOf(this.router, this.args.model.data);
   }
 
-  settingParams = ["hide", "from"];
+  sorted(benches: BenchmarkInfo[]) {
+    const sort = totalSortFrom(this.router);
+
+    if (!sort) return this.frameworks;
+
+    return sortedByTotal(
+      this.frameworks,
+      this.args.model.data,
+      benches,
+      percentileFrom(this.router),
+      sort,
+    );
+  }
+
+  @cached
+  get higherFrameworks() {
+    return this.sorted(higherIsBetterBenches(this.args.model.data.benchmarkInfo));
+  }
+
+  @cached
+  get lowerFrameworks() {
+    return this.sorted(lowerIsBetterBenches(this.args.model.data.benchmarkInfo));
+  }
+
+  frameworksFor = (benchInfo: BenchmarkInfo) =>
+    isBiggerBetter(benchInfo) ? this.higherFrameworks : this.lowerFrameworks;
+
+  settingParams = ["hide", "from", "sort"];
 
   get borrow() {
     return borrowOf(this.router, this.args.model.borrowed);
@@ -191,6 +228,8 @@ export default class Boxplat extends Component<{
 
   <template>
     <Settings @params={{this.settingParams}}>
+      <SortControl />
+
       <FrameworkToggles @file={{@model.data}} />
 
       <BorrowPicker @borrowed={{@model.borrowed}} />
@@ -215,7 +254,9 @@ export default class Boxplat extends Component<{
         {{! chart.js responsive sizing tracks the parent element,
             so the fixed height goes on a wrapper, not the canvas }}
         <div style="position: relative; height:{{this.height}}px;">
-          <canvas {{renderChart @model.data benchInfo this.frameworks this.borrow}}></canvas>
+          <canvas
+            {{renderChart @model.data benchInfo (this.frameworksFor benchInfo) this.borrow}}
+          ></canvas>
         </div>
       </section>
     {{/each}}

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -10,6 +10,7 @@ import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
+import { SortControl } from "#components/sort-control.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
@@ -22,9 +23,11 @@ import {
   percentileFrom,
   PERCENTILES,
   round,
+  sortedByTotal,
   throttleLabel,
   timeFor,
   titleOf,
+  totalSortFrom,
   variantOf,
   versionOf,
 } from "#utils";
@@ -456,7 +459,7 @@ export default class ResultsTables extends Component<{
     return visibleFrameworksOf(this.router, this.file);
   }
 
-  settingParams = ["mode", "p", "hide", "from"];
+  settingParams = ["mode", "p", "hide", "from", "sort"];
 
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo;
@@ -470,6 +473,24 @@ export default class ResultsTables extends Component<{
   @cached
   get lowerBenches() {
     return lowerIsBetterBenches(this.benchmarkInfo);
+  }
+
+  sorted(benches: BenchmarkInfo[]) {
+    const sort = totalSortFrom(this.router);
+
+    if (!sort) return this.visibleFrameworks;
+
+    return sortedByTotal(this.visibleFrameworks, this.file, benches, this.percentile, sort);
+  }
+
+  @cached
+  get higherFrameworks() {
+    return this.sorted(this.higherBenches);
+  }
+
+  @cached
+  get lowerFrameworks() {
+    return this.sorted(this.lowerBenches);
   }
 
   <template>
@@ -525,6 +546,8 @@ export default class ResultsTables extends Component<{
         <span class="units">of each run's samples</span>
       </fieldset>
 
+      <SortControl />
+
       <FrameworkToggles @file={{this.file}} />
 
       <BorrowPicker @borrowed={{@model.borrowed}} />
@@ -536,7 +559,7 @@ export default class ResultsTables extends Component<{
       <Table
         @benches={{this.higherBenches}}
         @file={{this.file}}
-        @frameworkNames={{this.visibleFrameworks}}
+        @frameworkNames={{this.higherFrameworks}}
         @borrow={{this.borrow}}
       />
       <br />
@@ -550,7 +573,7 @@ export default class ResultsTables extends Component<{
       <Table
         @benches={{this.lowerBenches}}
         @file={{this.file}}
-        @frameworkNames={{this.visibleFrameworks}}
+        @frameworkNames={{this.lowerFrameworks}}
         @borrow={{this.borrow}}
       />
       <br />

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -415,6 +415,59 @@ export function percentileFrom(router: RouterService): Percentile {
   return found ?? DEFAULT_PERCENTILE;
 }
 
+export type TotalSort = "best" | "worst";
+
+/**
+ * The `?sort=` query param, wherever a component needs it.
+ * Absent (or anything unrecognized) means the recorded order.
+ */
+export function totalSortFrom(router: RouterService): TotalSort | undefined {
+  const sort = router.currentRoute?.queryParams["sort"];
+
+  return sort === "best" || sort === "worst" ? sort : undefined;
+}
+
+/**
+ * Frameworks ordered by their summed result over one area's benches.
+ *
+ * "best" and "worst" are stated in the area's own direction -- best-first
+ * is the highest total when bigger is better and the lowest when smaller
+ * is -- so the same setting reads coherently across both areas. Frameworks
+ * the set has no data for go last either way.
+ */
+export function sortedByTotal(
+  frameworkNames: string[],
+  file: ResultSet,
+  benches: BenchmarkInfo[],
+  percentile: Percentile,
+  sort: TotalSort,
+) {
+  const totals: Record<string, number> = {};
+
+  for (const framework of frameworkNames) {
+    for (const bench of benches) {
+      const time = timeFor(file, framework, bench, percentile);
+
+      if (time === undefined) continue;
+
+      totals[framework] = (totals[framework] ?? 0) + time;
+    }
+  }
+
+  const descending = (sort === "best") === (benches[0]?.whatsBetter === "bigger");
+
+  return frameworkNames.toSorted((a, b) => {
+    const totalA = totals[a];
+    const totalB = totals[b];
+
+    if (totalA === undefined && totalB === undefined) return 0;
+    if (totalA === undefined) return 1;
+    if (totalB === undefined) return -1;
+
+    return descending ? totalB - totalA : totalA - totalB;
+  });
+}
+
 export function labelFor(percentile: Percentile) {
   return percentile === 50 ? "p50 (median)" : `p${percentile}`;
 }


### PR DESCRIPTION
Adds the requested setting for sorting by total: a `sort` fieldset in the collapsed settings panel with three radios — `default order`, `best total first`, `worst total first` — annotated "within each result area".

## UX + semantics

- The choice persists in a `?sort=` query param (`best` | `worst`; absent = default order). Like `mode`/`p`/`hide`, it is route-declared with no model impact, read live off `router.currentRoute`, and cleared by transitioning with `sort: null`. The settings panel still starts closed and auto-opens when the QP is set, on both pages (`sort` added to each page's `@params`).
- **Per-area direction:** a framework's total is its summed result over one area's benches, and "best"/"worst" are stated in that area's own direction. `best` puts the highest FPS totals first in *higher is better* and the lowest duration totals first in *lower is better*; `worst` is the exact reverse. The two areas of the table page sort independently, so each reads best-to-worst (or worst-to-best) on its own terms.
- **Table page:** reorders the framework columns of each area's table; the totals row confirms the ordering at a glance. Ties keep the recorded order (stable sort), so the all-120-FPS p50 dbmon row doesn't shuffle arbitrarily.
- **Boxplot page:** reorders each chart's rows, using the chart's area total — every chart in the same area shares one ordering, rather than each chart re-ranking by its own bench.
- **Composes with `?hide=`:** only visible frameworks participate; totals are summed over exactly the shown columns.
- **Borrowed column stays pinned last** rather than joining the ordering: it comes from a different run (potentially a different CPU throttle, which the header already flags), so ranking it among the viewed run's columns would imply a comparability the page elsewhere warns against — and it keeps its labeled edge position in both views.
- Frameworks a set has no data for in an area sort last in either direction.

## Implementation

- `sortedByTotal()` + `totalSortFrom()` in `#utils`, shared by both pages; one `SortControl` component rendered into the settings panel of each.
- `sort: {}` QP on the results route.

Verified in the dev server at 1920px: both directions on both pages (using `p=90` where p50 FPS values tie), URL round-trip, `hide` + borrowed-column composition, panel closed by default with the native caret, sticky header and no horizontal page overflow intact. `pnpm lint` and `pnpm build` green in `results/`, repo-root lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)