### PR TITLE
Separate the Incrementing Render Effect into its own Effects table section

### DIFF
--- a/results/app/templates/compare.gts
+++ b/results/app/templates/compare.gts
@@ -13,6 +13,7 @@ import { Version } from "#components/version.gts";
 import { nameOf } from "#frameworks";
 import { joinRuns } from "#routes/compare.ts";
 import {
+  effectsBenches,
   formatRunName,
   getFrameworks,
   higherIsBetterBenches,
@@ -445,6 +446,11 @@ export default class Compare extends Component<{ model: Model }> {
     return lowerIsBetterBenches(this.benchmarkInfo);
   }
 
+  @cached
+  get effectBenches() {
+    return effectsBenches(this.benchmarkInfo);
+  }
+
   /**
    * The variant any run recorded for the compared framework, preferring
    * the candidates (B onward). Runs are usually the same build, so this
@@ -557,6 +563,17 @@ export default class Compare extends Component<{ model: Model }> {
 
         <CompareTable
           @benches={{this.lowerBenches}}
+          @a={{this.a}}
+          @bs={{this.bs}}
+          @framework={{this.framework}}
+        />
+      {{/if}}
+
+      {{#if this.effectBenches.length}}
+        <h2>effects (lower is better)</h2>
+
+        <CompareTable
+          @benches={{this.effectBenches}}
           @a={{this.a}}
           @bs={{this.bs}}
           @framework={{this.framework}}

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -14,8 +14,10 @@ import { SortControl } from "#components/sort-control.gts";
 import { frameworks } from "#frameworks";
 import {
   columnsFor,
+  effectsBenches,
   formatRunName,
   higherIsBetterBenches,
+  isEffectsBench,
   lowerIsBetterBenches,
   percentileFrom,
   samplesOf,
@@ -199,8 +201,17 @@ export default class Boxplat extends Component<{
     return this.sorted(lowerIsBetterBenches(this.args.model.data.benchmarkInfo));
   }
 
-  columnsForBench = (benchInfo: BenchmarkInfo) =>
-    isBiggerBetter(benchInfo) ? this.higherColumns : this.lowerColumns;
+  @cached
+  get effectColumns() {
+    return this.sorted(effectsBenches(this.args.model.data.benchmarkInfo));
+  }
+
+  columnsForBench = (benchInfo: BenchmarkInfo) => {
+    if (isBiggerBetter(benchInfo)) return this.higherColumns;
+    if (isEffectsBench(benchInfo)) return this.effectColumns;
+
+    return this.lowerColumns;
+  };
 
   settingParams = ["hide", "from", "sort"] as const;
 

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -17,6 +17,7 @@ import {
   columnsFor,
   curveFrom,
   DEFAULT_CURVE,
+  effectsBenches,
   formatRunName,
   higherIsBetterBenches,
   labelFor,
@@ -461,6 +462,11 @@ export default class ResultsTables extends Component<{
     return lowerIsBetterBenches(this.benchmarkInfo);
   }
 
+  @cached
+  get effectBenches() {
+    return effectsBenches(this.benchmarkInfo);
+  }
+
   sorted(benches: BenchmarkInfo[]) {
     return sortedByTotal(this.columns, benches, this.percentile, totalSortFrom(this.queryParams));
   }
@@ -473,6 +479,11 @@ export default class ResultsTables extends Component<{
   @cached
   get lowerColumns() {
     return this.sorted(this.lowerBenches);
+  }
+
+  @cached
+  get effectColumns() {
+    return this.sorted(this.effectBenches);
   }
 
   <template>
@@ -563,6 +574,15 @@ export default class ResultsTables extends Component<{
       <h2>lower is better</h2>
 
       <Table @benches={{this.lowerBenches}} @file={{this.file}} @columns={{this.lowerColumns}} />
+      <br />
+      <br />
+      <br />
+    {{/if}}
+
+    {{#if this.effectBenches.length}}
+      <h2>effects (lower is better)</h2>
+
+      <Table @benches={{this.effectBenches}} @file={{this.file}} @columns={{this.effectColumns}} />
       <br />
       <br />
       <br />

--- a/results/app/types.ts
+++ b/results/app/types.ts
@@ -73,6 +73,11 @@ export interface BenchmarkInfo {
   measure?: string;
   whatsBetter: "bigger" | "smaller";
   units: string;
+  /**
+   * Which table section this bench is shown under.
+   * Benches without a section are grouped by `whatsBetter` alone.
+   */
+  section?: "effects";
 }
 
 export interface ResultSet {

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -561,9 +561,21 @@ export function higherIsBetterBenches(benchmarkInfo: BenchmarkInfo[]) {
   return benchmarkInfo.filter((bench) => bench.whatsBetter === "bigger");
 }
 
+/**
+ * Result sets recorded before `section` existed don't carry it,
+ * so the app name backfills membership for them.
+ */
+export function isEffectsBench(bench: BenchmarkInfo) {
+  return bench.section === "effects" || bench.app === "incrementing-render-effect";
+}
+
+export function effectsBenches(benchmarkInfo: BenchmarkInfo[]) {
+  return benchmarkInfo.filter((bench) => isEffectsBench(bench));
+}
+
 export function lowerIsBetterBenches(benchmarkInfo: BenchmarkInfo[]) {
   return benchmarkInfo
-    .filter((bench) => bench.whatsBetter !== "bigger")
+    .filter((bench) => bench.whatsBetter !== "bigger" && !isEffectsBench(bench))
     .toSorted()
     .toSorted((a, b) => (a.name.includes("async") ? 1 : 0) - (b.name.includes("async") ? 1 : 0));
 }

--- a/src/runner/bench-info.ts
+++ b/src/runner/bench-info.ts
@@ -65,6 +65,12 @@ export interface BenchmarkInfo {
    * What units are measured? this will be displayed in the UI
    */
   units: string;
+
+  /**
+   * Which table section the results app shows this bench under.
+   * Benches without a section are grouped by `whatsBetter` alone.
+   */
+  section?: 'effects';
 }
 
 const variants = [
@@ -100,6 +106,7 @@ const benchmarks: BenchmarkInfo[] = [
     query: '&updates=100000',
     whatsBetter: 'smaller',
     units: 'ms',
+    section: 'effects',
   },
   {
     name: '1 item, 1k updates (async)',


### PR DESCRIPTION
The Incrementing Render Effect bench measures something different enough from the update-timing benches that it was skewing the lower-is-better table's Total (802ms for React Compiler in run 7, vs single-digit rows). It now gets its own **Effects (lower is better)** section on the results and compare pages.

How:
- Benches can declare a table section: `section: 'effects'` on `BenchmarkInfo` (runner + app types). The runner records it into new result sets; result sets recorded before the field existed are backfilled by app name (`incrementing-render-effect`), so all existing runs group correctly.
- `lowerIsBetterBenches()` excludes effects benches; new `effectsBenches()` / `isEffectsBench()` in `#utils`.
- Results tables + compare pages render the new section (same `Table`/`CompareTable` components, so coloring, value modes, percentiles, and borrow columns all behave the same — lower-is-better follows from `whatsBetter: 'smaller'`).
- Boxplot still shows every bench chart; the effects chart now takes its framework ordering from its own section's totals when `sort` is active.

Verified against run 7 at 1920px: three sections render, the Effects table colors on its own scale, `?sort=best` orders the Effects table by its own bench, and the lower-is-better Total no longer includes the effect bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)