### PR TITLE
Document the repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,9 @@
 > [!NOTE]  
 > This whole repo should be taken with a grain of salt right now. The benchmarks are still being developed. 
 
-
-## TODOs
-
-- create lints 
-  - we don't want to prescribe pnpm vs npm vs yarn, so folks should provide an
-    - install.sh and a build.sh?
-    - config file? yaml? everyone loves yaml
-
-- create ci check to comment back on the PR if the src/runner can't access the build:prod output
-    - require that all apps in a framework folder have the same
-      - install
-      - build
-      - framework version
-
------------------------------------------
-
-
 This is the Reactivity and Rendering Benchmark for frontend application and component frameworks.
 
+- [Repository layout](#repository-layout)
 - [Motivation](#motivation)
 - [Methodology](#methodology)
   - [The Benchmarks](#the-benchmarks)
@@ -29,6 +13,22 @@ This is the Reactivity and Rendering Benchmark for frontend application and comp
   - [Reliability](#reliability)
 - [Adding a new framework](#adding-a-new-framework)
 - [Running the Benchmark](#running-the-benchmark)
+- [Roadmap](#roadmap)
+
+## Repository layout
+
+| directory | what it is |
+| --- | --- |
+| [`src/runner/`](./src/runner/) | the benchmark runner: builds and serves each app, drives Chrome over puppeteer, records `performance.mark`s into a result file |
+| [`frameworks/<framework>/<bench>/`](./frameworks/) | one standalone app per framework per bench -- what actually gets measured |
+| [`common/`](./common/) | the shared bench harness every app links: the workloads, DOM verification, and the FPS meter |
+| [`results/`](./results/) | the results viewer (an Ember app) *and* the recorded data it renders (`results/public/results/*.json`, experiments in `results/public/experiments/`) |
+| [`tests/`](./tests/) | playwright suite asserting every app works and (opt-in) that every framework does identical work |
+
+The pipeline: the runner loads each app from `frameworks/`, the app runs a
+workload from `common/` and emits performance marks, the runner writes them
+to a JSON file under `results/public/`, and the app in `results/` renders
+those files.
 
 
 ## Motivation
@@ -321,3 +321,15 @@ PR on `emberjs/ember.js` (or just its number). It builds that PR, installs the b
 in every ember app, and opens a draft PR here with the result -- check it out, and
 `pnpm bench`.
 
+
+## Roadmap
+
+- create lints
+  - we don't want to prescribe pnpm vs npm vs yarn, so folks should provide an
+    - install.sh and a build.sh?
+    - config file? yaml? everyone loves yaml
+- create ci check to comment back on the PR if the src/runner can't access the build:prod output
+  - require that all apps in a framework folder have the same
+    - install
+    - build
+    - framework version

--- a/common/README.md
+++ b/common/README.md
@@ -3,7 +3,7 @@
 The shared bench harness. Every app in `frameworks/<framework>/<bench>/`
 depends on this package (via `link:../../../common`), so all frameworks run
 **the same workload, verification, and measurement code** -- the only thing
-a framework app supplies is the rendering.
+a framework app supplies is the rendering and reactivity.
 
 What's here:
 

--- a/common/README.md
+++ b/common/README.md
@@ -28,6 +28,6 @@ test.doit((value) => {
 });
 ```
 
-Because the apps link this package, `pnpm install` must run *here* before
+Because the apps link this package, `pnpm install` must run _here_ before
 the apps build -- the runner does that automatically (pnpm does not install
 dependencies of linked packages).

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,33 @@
+# common
+
+The shared bench harness. Every app in `frameworks/<framework>/<bench>/`
+depends on this package (via `link:../../../common`), so all frameworks run
+**the same workload, verification, and measurement code** -- the only thing
+a framework app supplies is the rendering.
+
+What's here:
+
+- `src/tests/` -- one driver per bench (`one-item`, `many-items`, `fan-out`,
+  `incrementing-render-effect`, `db-mon-with-chat`), all built on
+  `base-test.js`. A driver reads its workload from query params (seeded, so
+  every framework gets byte-identical work), calls the app back to perform
+  each update, verifies the final DOM, and emits the `:start` / `:done`
+  performance marks the runner records.
+- `src/fps.js` -- the sliding-window FPS meter the dbmon bench samples.
+- `src/tests/dbmon/` -- the web workers (db mutations, chat) that drive the
+  dbmon bench off the main thread.
+
+An app uses it like:
+
+```js
+import { helpers } from 'common';
+
+const test = helpers.fanOut();
+test.doit((value) => {
+  /* render `value` however the framework renders */
+});
+```
+
+Because the apps link this package, `pnpm install` must run *here* before
+the apps build -- the runner does that automatically (pnpm does not install
+dependencies of linked packages).

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -1,0 +1,35 @@
+# frameworks
+
+One directory per framework, one **standalone app** per bench inside it:
+
+```
+frameworks/<framework>/<bench>/
+```
+
+The bench names must match across frameworks (`dbmon-with-chat`, `fan-out`,
+`incrementing-render-effect`, `one-item-many-updates`,
+`ten-k-items-one-time`) -- the runner pairs each bench in its catalog with
+the app directory of that name for every framework.
+
+## The contract for an app
+
+- it installs with `pnpm install` and builds with `pnpm build` into `dist/`
+  (that's what the runner runs and serves)
+- it depends on `common` via `link:../../../common` and drives the bench
+  through its helpers, so the workload and measurement are identical across
+  frameworks -- the app only supplies the rendering
+- apps are deliberately **not** part of a workspace: each has its own
+  lockfile, so framework versions are isolated and `pnpm use-tar-for` can
+  point one framework at a tarball without touching the others
+
+Optional per-framework files:
+
+- `README.md` -- how to scaffold a new bench app for this framework
+- `notes.json` -- small labels recorded into a run, e.g. Vue's
+  `{ "variant": "Vapor" }`, shown in the results app
+
+## Adding a framework
+
+See "Adding a new framework" in the [root README](../README.md): register
+it in `results/app/frameworks.ts`, add a logo to `results/public/`, then
+implement each bench here.

--- a/results/README.md
+++ b/results/README.md
@@ -1,57 +1,35 @@
 # results
 
-This README outlines the details of collaborating on this Ember application.
-A short introduction of this app could easily go here.
+Two things live here:
 
-## Prerequisites
+- **the recorded data**: `public/results/*.json` (official runs, numbered
+  sequentially) and `public/experiments/*.json` (one-off runs, e.g. from
+  `pnpm use-tar-for`). These files are written by the runner in
+  `../src/runner/` -- their shape is described by `ResultSet` in
+  [`app/types.ts`](./app/types.ts).
+- **the viewer**: an Ember app that renders those files -- the tables,
+  boxplots, animated view, and run-to-run compare.
 
-You will need the following things properly installed on your computer.
+## Running the viewer
 
-- [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/)
-- [pnpm](https://pnpm.io/)
-- [Ember CLI](https://cli.emberjs.com/release/)
-- [Google Chrome](https://google.com/chrome/)
+```bash
+cd results
+pnpm install
+pnpm start
+```
 
-## Installation
+`pnpm build` produces the production build, `pnpm lint:types` type-checks.
 
-- `git clone <repository-url>` this repository
-- `cd results`
-- `pnpm install`
+## Where things are
 
-## Running / Development
+| path | what it is |
+| --- | --- |
+| `app/types.ts` | the shape of a result file -- the contract with the runner |
+| `app/utils.ts` | formatting, query-param readers, statistics |
+| `app/frameworks.ts` | the framework registry (display name, color, logo, package to read the version from) -- shared with the runner |
+| `app/templates/results/` | the three views of one run: table, boxplot, animated |
+| `app/templates/compare.gts` | one framework across N runs |
+| `vite.config.mjs` | builds `virtual:result-sets`: the list of runs and the build-time metadata (date, browser, throttle) their display names are made of |
 
-- `pnpm start`
-- Visit your app at [http://localhost:4200](http://localhost:4200).
-- Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
-
-### Code Generators
-
-Make use of the many generators for code, try `ember help generate` for more details
-
-### Running Tests
-
-- `pnpm test`
-- `pnpm test:ember --server`
-
-### Linting
-
-- `pnpm lint`
-- `pnpm lint:fix`
-
-### Building
-
-- `pnpm ember build` (development)
-- `pnpm build` (production)
-
-### Deploying
-
-Specify what it takes to deploy your app.
-
-## Further Reading / Useful Links
-
-- [ember.js](https://emberjs.com/)
-- [ember-cli](https://cli.emberjs.com/release/)
-- Development Browser Extensions
-  - [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
-  - [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+Result files are fetched at runtime by name; nothing needs rebuilding when
+a new JSON lands in `public/results/`.


### PR DESCRIPTION
## What

Findability pass — no code changes, docs only.

- **Root README**: opens with a directory map + the pipeline (`runner → frameworks apps → common harness → results JSON → viewer`) instead of the TODO list; TODOs move to a `Roadmap` section at the bottom.
- **`results/README.md`**: was still the ember-cli scaffold ("visit localhost:4200", generators, a test suite that doesn't exist). Now says what the directory actually is — recorded data + the viewer — with a where-things-are table.
- **`common/README.md`** (new): explains it's the shared bench harness (workloads, DOM verification, `:start`/`:done` marks, FPS meter), the `link:` relationship, and why its own `pnpm install` matters.
- **`frameworks/README.md`** (new): the contract for a bench app (same-named dir per bench, `pnpm install` / `pnpm build` → `dist/`, `common` via link), and why the apps are deliberately not a workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)