### PR TITLE
Bend the heatmap color ramp toward the best result

### DIFF
--- a/results/app/components/settings.gts
+++ b/results/app/components/settings.gts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 
-import { DEFAULT_PERCENTILE } from "#utils";
+import { DEFAULT_CURVE, DEFAULT_PERCENTILE } from "#utils";
 
 import type Owner from "@ember/owner";
 import type RouterService from "@ember/routing/router-service";
@@ -9,6 +9,7 @@ import type RouterService from "@ember/routing/router-service";
 const DEFAULTS: Record<string, string> = {
   mode: "raw",
   p: String(DEFAULT_PERCENTILE),
+  curve: String(DEFAULT_CURVE),
 };
 
 function hasNonDefaults(router: RouterService, params: string[]) {

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -36,6 +36,9 @@ export default class Results extends Route<Model> {
     sort: {},
     // display mode for the tables page (raw | linear | log); no model impact
     mode: {},
+    // how hard the heatmap ramp bends toward each row's best value;
+    // purely a color choice, so no model impact
+    curve: {},
     // which percentile of each run's samples to show (50 | 75 | 90);
     // every sample is already loaded, so no model impact
     p: {},

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -432,7 +432,8 @@ table {
      the page; a hairline like the fieldset's own suits it better. The
      dropdown itself stays native, and color-scheme keeps it legible. */
   select,
-  button {
+  button,
+  input[type="number"] {
     font-family: inherit;
     font-size: 0.9rem;
     padding: 0.125rem 0.375rem;
@@ -449,6 +450,15 @@ table {
 
   button {
     cursor: pointer;
+  }
+
+  /* a number field defaults to a text field's width, which would make its
+     fieldset twice as wide as every other one in the stack */
+  input[type="number"] {
+    width: 4rem;
+    cursor: text;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
   }
 }
 

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -45,7 +45,7 @@ const best = "#77ff77";
 const gradient = interpolate([best, worst], "oklch");
 
 /** how hard the ramp bends toward the best value; 0 is linear */
-const CURVE = 13;
+const CURVE = 20;
 
 /**
  * Where a value sits on the gradient, given how far it is from the row's

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -45,7 +45,7 @@ const best = "#77ff77";
 const gradient = interpolate([best, worst], "oklch");
 
 /** how hard the ramp bends toward the best value; 0 is linear */
-const CURVE = 9;
+const CURVE = 7;
 
 /**
  * Where a value sits on the gradient, given how far it is from the row's

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -14,6 +14,8 @@ import { SortControl } from "#components/sort-control.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
+  curveFrom,
+  DEFAULT_CURVE,
   formatRunName,
   higherIsBetterBenches,
   isoOf,
@@ -44,20 +46,20 @@ const best = "#77ff77";
 /** green at 0, red at 1, so the ramp is always indexed by distance from the best value */
 const gradient = interpolate([best, worst], "oklch");
 
-/** how hard the ramp bends toward the best value; 0 is linear */
-const CURVE = 2;
-
 /**
  * Where a value sits on the gradient, given how far it is from the row's
  * best result as a fraction of the row's spread.
  *
  * Spending that distance linearly hands the whole scale to the slowest
  * framework: when the worst result is 20x the best, everything within 2x
- * of the winner lands on the same green. A log ramp gives the close race
- * at the top most of the colors and lets the tail share the red.
+ * of the winner lands on the same green. Bending it logarithmically gives
+ * the close race at the top more of the colors and lets the tail share the
+ * red. `curve` is how hard it bends -- 0 is the straight linear ramp.
  */
-function rampFromBest(distance: number) {
-  return Math.log1p(CURVE * distance) / Math.log1p(CURVE);
+function rampFromBest(distance: number, curve: number) {
+  if (curve <= 0) return distance;
+
+  return Math.log1p(curve * distance) / Math.log1p(curve);
 }
 
 function colorFor(
@@ -65,11 +67,12 @@ function colorFor(
   min: number | undefined,
   max: number | undefined,
   reverse = false,
+  curve = DEFAULT_CURVE,
 ) {
   if (!speed || !min || !max) return;
 
   const normalized = (speed - min) / (max - min);
-  const color = gradient(rampFromBest(reverse ? 1 - normalized : normalized));
+  const color = gradient(rampFromBest(reverse ? 1 - normalized : normalized, curve));
 
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }
@@ -175,13 +178,14 @@ class TableRow extends Component<{
     }
 
     const reverse = this.args.benchInfo.whatsBetter === "bigger";
+    const curve = curveFrom(this.router);
     const colors: Record<string, string | undefined> = {};
 
     for (const framework of this.args.frameworkNames) {
-      colors[framework] = colorFor(speeds[framework], lo, hi, reverse);
+      colors[framework] = colorFor(speeds[framework], lo, hi, reverse, curve);
     }
 
-    const borrowedColor = colorFor(borrowedSpeed, lo, hi, reverse);
+    const borrowedColor = colorFor(borrowedSpeed, lo, hi, reverse, curve);
 
     return { speeds, min: lo, max: hi, colors, borrowedSpeed, borrowedColor };
   }
@@ -321,6 +325,17 @@ class Table extends Component<{
     return throttleLabel(theirs);
   }
 
+  /**
+   * Every bench in one area shares a direction, so the totals row reads
+   * in that area's direction too.
+   */
+  get bestIsMax() {
+    return this.args.benches[0]?.whatsBetter === "bigger";
+  }
+
+  totalColor = (total: number | undefined) =>
+    colorFor(total, this.totals.min, this.totals.max, this.bestIsMax, curveFrom(this.router));
+
   totalValue = (framework: string) => {
     const total = this.totals[framework];
 
@@ -329,12 +344,7 @@ class Table extends Component<{
         return scoreFor(total, this.totals.min, this.totals.max);
       case "times": {
         // times-best of the raw totals, so the best column reads 1x
-        const ratio = timesBestFor(
-          total,
-          this.totals.min,
-          this.totals.max,
-          this.args.benches[0]?.whatsBetter === "bigger",
-        );
+        const ratio = timesBestFor(total, this.totals.min, this.totals.max, this.bestIsMax);
 
         return ratio === undefined ? undefined : formatTimes(ratio);
       }
@@ -405,26 +415,13 @@ class Table extends Component<{
         <tfoot>
           <tr><th style="text-align: right">Total</th>
             {{#each this.frameworkNames as |framework|}}
-              <td
-                style="background: {{colorFor
-                  (get this.totals framework)
-                  this.totals.min
-                  this.totals.max
-                }}"
-              >
+              <td style="background: {{this.totalColor (get this.totals framework)}}">
                 <span class="value">{{this.totalValue framework}}</span>
               </td>
             {{/each}}
 
             {{#if @borrow}}
-              <td
-                class="borrowed"
-                style="background: {{colorFor
-                  this.totals.borrowed
-                  this.totals.min
-                  this.totals.max
-                }}"
-              >
+              <td class="borrowed" style="background: {{this.totalColor this.totals.borrowed}}">
                 <span class="value">{{this.totalValue "borrowed"}}</span>
               </td>
             {{/if}}
@@ -462,6 +459,21 @@ export default class ResultsTables extends Component<{
 
   isPercentile = (percentile: Percentile) => this.percentile === percentile;
 
+  get curve() {
+    return curveFrom(this.router);
+  }
+
+  setCurve = (event: Event) => {
+    const { valueAsNumber } = event.target as HTMLInputElement;
+    // an emptied or unparseable field falls back to the default rather
+    // than leaving the tables uncolored while you retype
+    const curve = Number.isFinite(valueAsNumber) ? Math.max(0, valueAsNumber) : DEFAULT_CURVE;
+
+    this.router.transitionTo({
+      queryParams: { curve: curve === DEFAULT_CURVE ? null : curve },
+    });
+  };
+
   labelFor = labelFor;
 
   get file() {
@@ -476,7 +488,7 @@ export default class ResultsTables extends Component<{
     return visibleFrameworksOf(this.router, this.file);
   }
 
-  settingParams = ["mode", "p", "hide", "from", "sort"];
+  settingParams = ["mode", "p", "hide", "from", "sort", "curve"];
 
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo;
@@ -561,6 +573,22 @@ export default class ResultsTables extends Component<{
         {{! percentiles run toward the worse end either way, so the same
           number means the same thing on both tables }}
         <span class="units">of each run's samples</span>
+      </fieldset>
+
+      <fieldset class="value-mode">
+        <legend>color curve</legend>
+        <label>
+          <input
+            type="number"
+            name="color-curve"
+            min="0"
+            step="any"
+            value={{this.curve}}
+            {{on "change" this.setCurve}}
+          />
+          bend toward best
+        </label>
+        <span class="units">0 is a straight ramp; higher favors the leaders</span>
       </fieldset>
 
       <SortControl />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -473,12 +473,15 @@ export default class ResultsTables extends Component<{
 
   setCurve = (event: Event) => {
     const { valueAsNumber } = event.target as HTMLInputElement;
-    // an emptied or unparseable field falls back to the default rather
-    // than leaving the tables uncolored while you retype
-    const curve = Number.isFinite(valueAsNumber) ? valueAsNumber : DEFAULT_CURVE;
+
+    // Half-typed input is briefly unparseable -- "", "-", "0." -- and this
+    // fires on every keystroke. Keep the last good curve instead of writing
+    // a fallback back into the field, which would eat the keystroke and
+    // make a negative impossible to type.
+    if (!Number.isFinite(valueAsNumber)) return;
 
     this.router.transitionTo({
-      queryParams: { curve: curve === DEFAULT_CURVE ? null : curve },
+      queryParams: { curve: valueAsNumber === DEFAULT_CURVE ? null : valueAsNumber },
     });
   };
 
@@ -589,7 +592,7 @@ export default class ResultsTables extends Component<{
           <input
             type="number"
             name="color-curve"
-            step="any"
+            step="0.1"
             value={{this.curve}}
             {{on "input" this.setCurve}}
           />

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -45,7 +45,7 @@ const best = "#77ff77";
 const gradient = interpolate([best, worst], "oklch");
 
 /** how hard the ramp bends toward the best value; 0 is linear */
-const CURVE = 7;
+const CURVE = 13;
 
 /**
  * Where a value sits on the gradient, given how far it is from the row's

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -591,7 +591,7 @@ export default class ResultsTables extends Component<{
             name="color-curve"
             step="any"
             value={{this.curve}}
-            {{on "change" this.setCurve}}
+            {{on "input" this.setCurve}}
           />
           bend toward best
         </label>

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -45,7 +45,7 @@ const best = "#77ff77";
 const gradient = interpolate([best, worst], "oklch");
 
 /** how hard the ramp bends toward the best value; 0 is linear */
-const CURVE = 20;
+const CURVE = 2;
 
 /**
  * Where a value sits on the gradient, given how far it is from the row's

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -38,8 +38,27 @@ import type { Model } from "#routes/results.ts";
 import type { BenchmarkInfo, ResultSet } from "#types";
 import type { Percentile } from "#utils";
 
-const start = "#ff7777";
-const end = "#77ff77";
+const worst = "#ff7777";
+const best = "#77ff77";
+
+/** green at 0, red at 1, so the ramp is always indexed by distance from the best value */
+const gradient = interpolate([best, worst], "oklch");
+
+/** how hard the ramp bends toward the best value; 0 is linear */
+const CURVE = 9;
+
+/**
+ * Where a value sits on the gradient, given how far it is from the row's
+ * best result as a fraction of the row's spread.
+ *
+ * Spending that distance linearly hands the whole scale to the slowest
+ * framework: when the worst result is 20x the best, everything within 2x
+ * of the winner lands on the same green. A log ramp gives the close race
+ * at the top most of the colors and lets the tail share the red.
+ */
+function rampFromBest(distance: number) {
+  return Math.log1p(CURVE * distance) / Math.log1p(CURVE);
+}
 
 function colorFor(
   speed: number | undefined,
@@ -49,10 +68,8 @@ function colorFor(
 ) {
   if (!speed || !min || !max) return;
 
-  const interpolation = interpolate(reverse ? [start, end] : [end, start], "oklch");
-
   const normalized = (speed - min) / (max - min);
-  const color = interpolation(normalized);
+  const color = gradient(rampFromBest(reverse ? 1 - normalized : normalized));
 
   return `oklch(${color.l} ${color.c} ${color.h}deg)`;
 }

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -54,10 +54,18 @@ const gradient = interpolate([best, worst], "oklch");
  * framework: when the worst result is 20x the best, everything within 2x
  * of the winner lands on the same green. Bending it logarithmically gives
  * the close race at the top more of the colors and lets the tail share the
- * red. `curve` is how hard it bends -- 0 is the straight linear ramp.
+ * red.
+ *
+ * `curve` is how hard it bends: 0 is the straight linear ramp, positive
+ * spends more of the gradient on the results nearest the best one, and
+ * negative does the same for the ones nearest the worst. Every real
+ * number lands somewhere useful, so the setting takes anything.
  */
-function rampFromBest(distance: number, curve: number) {
-  if (curve <= 0) return distance;
+function rampFromBest(distance: number, curve: number): number {
+  if (curve === 0) return distance;
+  // bending away from best is the same curve read from the other end.
+  // Feeding a negative straight to log1p would go imaginary past -1.
+  if (curve < 0) return 1 - rampFromBest(1 - distance, -curve);
 
   return Math.log1p(curve * distance) / Math.log1p(curve);
 }
@@ -467,7 +475,7 @@ export default class ResultsTables extends Component<{
     const { valueAsNumber } = event.target as HTMLInputElement;
     // an emptied or unparseable field falls back to the default rather
     // than leaving the tables uncolored while you retype
-    const curve = Number.isFinite(valueAsNumber) ? Math.max(0, valueAsNumber) : DEFAULT_CURVE;
+    const curve = Number.isFinite(valueAsNumber) ? valueAsNumber : DEFAULT_CURVE;
 
     this.router.transitionTo({
       queryParams: { curve: curve === DEFAULT_CURVE ? null : curve },
@@ -581,14 +589,13 @@ export default class ResultsTables extends Component<{
           <input
             type="number"
             name="color-curve"
-            min="0"
             step="any"
             value={{this.curve}}
             {{on "change" this.setCurve}}
           />
           bend toward best
         </label>
-        <span class="units">0 is a straight ramp; higher favors the leaders</span>
+        <span class="units">0 is a straight ramp; negative bends toward the tail</span>
       </fieldset>
 
       <SortControl />

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -414,6 +414,24 @@ export function percentileFrom(router: RouterService): Percentile {
   return found ?? DEFAULT_PERCENTILE;
 }
 
+export const DEFAULT_CURVE = 1;
+
+/**
+ * The `?curve=` query param: how hard the heatmap's color ramp bends
+ * toward the best value in each row. 0 is a straight linear ramp, and
+ * every step up spends more of the gradient on the results nearest the
+ * best one.
+ */
+export function curveFrom(router: RouterService): number {
+  const raw = router.currentRoute?.queryParams["curve"];
+
+  if (raw === undefined || raw === "") return DEFAULT_CURVE;
+
+  const curve = Number(raw);
+
+  return Number.isFinite(curve) && curve >= 0 ? curve : DEFAULT_CURVE;
+}
+
 export type TotalSort = "best" | "worst";
 
 /**

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -418,9 +418,9 @@ export const DEFAULT_CURVE = 1;
 
 /**
  * The `?curve=` query param: how hard the heatmap's color ramp bends
- * toward the best value in each row. 0 is a straight linear ramp, and
- * every step up spends more of the gradient on the results nearest the
- * best one.
+ * toward the best value in each row. 0 is a straight linear ramp, positive
+ * spends more of the gradient on the results nearest the best one, and
+ * negative does the same for the ones nearest the worst.
  */
 export function curveFrom(router: RouterService): number {
   const raw = router.currentRoute?.queryParams["curve"];
@@ -429,7 +429,7 @@ export function curveFrom(router: RouterService): number {
 
   const curve = Number(raw);
 
-  return Number.isFinite(curve) && curve >= 0 ? curve : DEFAULT_CURVE;
+  return Number.isFinite(curve) ? curve : DEFAULT_CURVE;
 }
 
 export type TotalSort = "best" | "worst";


### PR DESCRIPTION
Cell backgrounds interpolated green→red linearly across the row's `min..max`, so a single slow framework consumed the entire scale. In *1 value, 1k consumers, 10k updates (bursts of 100)*, SolidJS 1 is 15x the winner, so Angular (1376), Lit (1785), Vue Vapor (1901) and Ember (2318) — a real 1.7x spread — all rendered as the same bright green.

The gradient is now indexed by distance from the row's best value, and that distance is spent logarithmically. How hard it bends is the `?curve=` query param, exposed as a number field in settings:

| distance from best | `curve=0` | `curve=1` (default) | `curve=4` |
| --- | --- | --- | --- |
| 5% | 0.05 | 0.07 | 0.23 |
| 10% | 0.10 | 0.14 | 0.34 |
| 25% | 0.25 | 0.32 | 0.58 |
| 50% | 0.50 | 0.58 | 0.79 |

`curve=0` is the straight linear ramp the tables had before, so the old look is still reachable. Endpoints never move at any setting: best is full green, worst is full red, and `whatsBetter: "bigger"` rows still read in the right direction.

The default is 1 — a visible nudge away from linear without recoloring the whole table on arrival. Note the suggestion commits on this branch had settled on 2; say the word and I'll bump `DEFAULT_CURVE`.

Also here:

- Reordering the two gradient stops to always run best→worst let the interpolator move to module scope instead of being rebuilt per cell.
- The totals footer had been calling `colorFor` without its direction argument, which would color a multi-bench "higher is better" total backwards. Both footer cells now go through one `totalColor` that passes the direction and the curve, reusing the `bestIsMax` the totals *value* already computed. No visible change today, since the only higher-is-better area has a single bench.
- `input[type="number"]` picks up the same hairline chrome as the settings `select`s, and is narrowed so its fieldset doesn't end up twice the width of the others.

Verified at 1920px across `curve` 0/1/4/9 against run 8: `curve=0` reproduces the pre-PR colors exactly, the settings panel stays collapsed at the default and opens when the param is off-default, and lint, prettier and `ember-tsc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)