### PR TITLE
Stop the framework headers shoving themselves over the first rows

### DIFF
--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -240,11 +240,14 @@ table {
     white-space: nowrap;
   }
 
+  /* No position of its own: `thead th` above is already sticky, which both
+     pins the row and gives the borrow badge something to anchor against.
+     Setting position here outranks that rule (0,1,1 over 0,0,3), and the
+     `top` meant for the sticky offset becomes a relative one -- shoving
+     the headers a header-height down, over the first rows of the table. */
   .fw-header {
     text-align: center;
     vertical-align: bottom;
-    /* anchors the borrow badge */
-    position: relative;
   }
 
   /* benchmark names stay readable while the value columns scroll under them */


### PR DESCRIPTION
My fault, from #101.

`.fw-header` took `position: relative` to anchor the borrow badge. It never needed to — `thead th` above it is already `position: sticky`, which is a positioned ancestor and gives the badge the same containing block.

What it did instead was **outrank that rule**: `table .fw-header` at (0,1,1) beats `table thead th` at (0,0,3). So the header cells stopped being sticky, and the `top: var(--header-height)` meant as their sticky offset became a *relative* offset — pushing every framework header 64px down the page, over the first rows of the table.

On run 8 the first data row was completely hidden:

| | before | after |
| --- | --- | --- |
| computed `position` | `relative` | `sticky` |
| header bottom vs first row top | 64px of overlap | 0 |

The corner `p50 (median)` cell kept its own stickiness the whole time, which is why the header row looked visibly offset from it.

### Verified

At scroll offsets 0 / 700 / 1100 / 1400 on the tall table: the header cells report `sticky`, pin at a constant offset alongside the corner cell, and no header cell overlaps any body cell. The borrow badge still anchors to the top-left of its header — the sticky cell was always a perfectly good containing block for it.

Lint, prettier and `ember-tsc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)