### PR TITLE
Borrow more than one column at a time

### DIFF
--- a/results/app/components/borrow-picker.gts
+++ b/results/app/components/borrow-picker.gts
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
 
 import { experiments, runs } from "virtual:result-sets";
@@ -17,21 +18,38 @@ export interface Borrow {
   framework: string;
 }
 
-export function borrowOf(qp: QueryParams, borrowed: Borrowed | undefined): Borrow | undefined {
-  if (!borrowed) return;
+/** `?col=` is positional against `?from=`: one framework per borrowed run. */
+function requestedColumns(qp: QueryParams) {
+  const raw = qp.get("col");
 
-  const available = borrowed.data.selections.frameworks;
-  const requested = qp.get("col");
-  const framework =
-    requested !== undefined && available.includes(requested) ? requested : available[0];
+  return raw === undefined ? [] : raw.split(",");
+}
 
-  if (!framework) return;
+/**
+ * Every borrow currently on loan, in the order `?from=` lists them.
+ *
+ * A run whose requested framework it does not have falls back to its first
+ * one, so an edited URL degrades instead of dropping the column.
+ */
+export function borrowsOf(qp: QueryParams, borrowed: Borrowed[]): Borrow[] {
+  const requested = requestedColumns(qp);
+  const borrows: Borrow[] = [];
 
-  return { name: borrowed.name, data: borrowed.data, framework };
+  for (const [index, set] of borrowed.entries()) {
+    const available = set.data.selections.frameworks;
+    const asked = requested[index];
+    const framework = asked !== undefined && available.includes(asked) ? asked : available[0];
+
+    if (!framework) continue;
+
+    borrows.push({ name: set.name, data: set.data, framework });
+  }
+
+  return borrows;
 }
 
 export class BorrowPicker extends Component<{
-  borrowed: Borrowed | undefined;
+  borrowed: Borrowed[];
 }> {
   @service declare router: RouterService;
   @service declare queryParams: QueryParams;
@@ -40,88 +58,155 @@ export class BorrowPicker extends Component<{
     return this.queryParams.get("q") ?? "";
   }
 
-  get runOptions() {
-    return runs.filter((name) => name !== this.current);
-  }
+  /** the page's own run, and anything already borrowed, cannot be borrowed again */
+  options = (list: string[], index: number) => {
+    const taken = this.args.borrowed.map((set) => set.name);
 
-  get experimentOptions() {
-    return experiments.filter((name) => name !== this.current);
-  }
-
-  // only one borrow is possible so far; this becomes its position once
-  // several can be on loan at once
-  label = borrowLabel(0);
-
-  get framework() {
-    return borrowOf(this.queryParams, this.args.borrowed)?.framework ?? "";
-  }
-
-  get isNone() {
-    return !this.args.borrowed;
-  }
-
-  isSource = (name: string) => this.args.borrowed?.name === name;
-
-  isFramework = (name: string) => this.framework === name;
-
-  setSource = (event: Event) => {
-    const { value } = event.target as HTMLSelectElement;
-
-    this.router.transitionTo({ queryParams: { from: value || null, col: null } });
+    return list.filter(
+      (name) => name !== this.current && (name === taken[index] || !taken.includes(name)),
+    );
   };
 
-  setFramework = (event: Event) => {
-    const { value } = event.target as HTMLSelectElement;
+  runOptions = (index: number) => this.options(runs, index);
 
-    this.router.transitionTo({ queryParams: { col: value } });
+  experimentOptions = (index: number) => this.options(experiments, index);
+
+  /** the runs left to add, so the picker can hide its add control when empty */
+  get unborrowed() {
+    return this.options(runs.concat(experiments), -1);
+  }
+
+  @cached
+  get borrows() {
+    return borrowsOf(this.queryParams, this.args.borrowed);
+  }
+
+  labelAt = (index: number) => borrowLabel(index);
+
+  frameworkAt = (index: number) => this.borrows[index]?.framework ?? "";
+
+  isFrameworkAt = (index: number, name: string) => this.frameworkAt(index) === name;
+
+  isSourceAt = (index: number, name: string) => this.args.borrowed[index]?.name === name;
+
+  /**
+   * `from` and `col` are positional against each other, so every edit
+   * rewrites both lists together rather than touching one of them.
+   */
+  #commit(names: string[], frameworks: string[]) {
+    // a column nobody has chosen yet is empty, and resolves to its run's
+    // first framework. Trailing ones say nothing, so they stay out of the URL.
+    let end = frameworks.length;
+
+    while (end > 0 && !frameworks[end - 1]) end--;
+
+    const chosen = frameworks.slice(0, end);
+
+    this.router.transitionTo({
+      queryParams: {
+        from: names.join(",") || null,
+        col: chosen.length ? chosen.join(",") : null,
+      },
+    });
+  }
+
+  get names() {
+    return this.args.borrowed.map((set) => set.name);
+  }
+
+  get frameworks() {
+    return this.args.borrowed.map((_, index) => this.frameworkAt(index));
+  }
+
+  setSource = (index: number, event: Event) => {
+    const { value } = event.target as HTMLSelectElement;
+    const names = this.names.slice();
+    const frameworks = this.frameworks.slice();
+
+    names[index] = value;
+    // the new run may not have the old framework; borrowsOf falls back
+    frameworks[index] = "";
+
+    this.#commit(names, frameworks);
   };
 
-  remove = () => {
-    this.router.transitionTo({ queryParams: { from: null, col: null } });
+  setFramework = (index: number, event: Event) => {
+    const { value } = event.target as HTMLSelectElement;
+    const frameworks = this.frameworks.slice();
+
+    frameworks[index] = value;
+
+    this.#commit(this.names, frameworks);
+  };
+
+  add = () => {
+    const next = this.unborrowed[0];
+
+    if (!next) return;
+
+    this.#commit(this.names.concat(next), this.frameworks.concat(""));
+  };
+
+  removeAt = (index: number) => {
+    const names = this.names.slice();
+    const frameworks = this.frameworks.slice();
+
+    names.splice(index, 1);
+    frameworks.splice(index, 1);
+
+    this.#commit(names, frameworks);
   };
 
   <template>
     <fieldset class="borrow-controls surface">
-      <legend>borrow a column</legend>
-      <label>
-        from run
-        <select name="borrow-from" {{on "change" this.setSource}}>
-          <option value="" selected={{this.isNone}}>none</option>
-          <optgroup label="Runs">
-            {{#each this.runOptions as |name|}}
-              <option
-                value={{name}}
-                selected={{this.isSource name}}
-                title={{titleOf name}}
-              >{{formatRunName name}}</option>
-            {{/each}}
-          </optgroup>
-          {{#if this.experimentOptions.length}}
-            <optgroup label="Experiments">
-              {{#each this.experimentOptions as |name|}}
-                <option
-                  value={{name}}
-                  selected={{this.isSource name}}
-                  title={{titleOf name}}
-                >{{formatRunName name}}</option>
+      <legend>borrow columns</legend>
+
+      {{#each @borrowed as |set index|}}
+        <div class="borrow-row">
+          <span class="borrow-label">{{this.labelAt index}}</span>
+          <label>
+            from
+            <select name="borrow-from-{{index}}" {{on "change" (fn this.setSource index)}}>
+              <optgroup label="Runs">
+                {{#each (this.runOptions index) as |name|}}
+                  <option
+                    value={{name}}
+                    selected={{this.isSourceAt index name}}
+                    title={{titleOf name}}
+                  >{{formatRunName name}}</option>
+                {{/each}}
+              </optgroup>
+              {{#if (this.experimentOptions index)}}
+                <optgroup label="Experiments">
+                  {{#each (this.experimentOptions index) as |name|}}
+                    <option
+                      value={{name}}
+                      selected={{this.isSourceAt index name}}
+                      title={{titleOf name}}
+                    >{{formatRunName name}}</option>
+                  {{/each}}
+                </optgroup>
+              {{/if}}
+            </select>
+          </label>
+          <label>
+            framework
+            <select name="borrow-framework-{{index}}" {{on "change" (fn this.setFramework index)}}>
+              {{#each set.data.selections.frameworks as |name|}}
+                <option value={{name}} selected={{this.isFrameworkAt index name}}>{{nameOf
+                    name
+                  }}</option>
               {{/each}}
-            </optgroup>
-          {{/if}}
-        </select>
-      </label>
-      {{#if @borrowed}}
-        <label>
-          framework
-          <select name="borrow-framework" {{on "change" this.setFramework}}>
-            {{#each @borrowed.data.selections.frameworks as |name|}}
-              <option value={{name}} selected={{this.isFramework name}}>{{nameOf name}}</option>
-            {{/each}}
-          </select>
-        </label>
-        {{! the table header carries only this letter, so the run it stands
-            for has to be readable here }}
-        <span class="units">shown as <span class="borrow-label">{{this.label}}</span></span>
-        <button type="button" {{on "click" this.remove}}>remove</button>
+            </select>
+          </label>
+          <button type="button" {{on "click" (fn this.removeAt index)}}>remove</button>
+        </div>
+      {{/each}}
+
+      {{#if this.unborrowed}}
+        <button type="button" class="add-borrow" {{on "click" this.add}}>
+          {{if @borrowed.length "+ borrow another" "+ borrow a column"}}
+        </button>
       {{/if}}
     </fieldset>
   </template>

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -19,7 +19,8 @@ export interface Borrowed {
 
 export interface Model {
   data: ResultSet;
-  borrowed?: Borrowed;
+  /** every run with a column on loan, in the order `?from=` lists them */
+  borrowed: Borrowed[];
 }
 
 export default class Results extends Route<Model> {
@@ -27,9 +28,10 @@ export default class Results extends Route<Model> {
 
   queryParams = {
     q: { refreshModel: true },
+    // comma-separated: one run per borrowed column
     from: { refreshModel: true },
-    // which of the borrowed set's frameworks; the set is already loaded,
-    // so no model impact
+    // comma-separated, positional against `from`: which framework to take
+    // from each. Those sets are already loaded, so no model impact.
     col: {},
     hide: {},
     // order frameworks by their per-area totals (best | worst); no model impact
@@ -65,16 +67,18 @@ export default class Results extends Route<Model> {
     // SAFETY: verified in beforeModel
     const { q, from } = params as unknown as Params;
 
+    // duplicates would collide as columns and there is nothing to gain from
+    // borrowing the same run twice
+    const names = Array.from(new Set(from ? from.split(",").filter(Boolean) : []));
+
     try {
-      const [data, borrowedData] = await Promise.all([
+      // paired inside the fetch, so nothing has to line two arrays back up
+      const [data, borrowed] = await Promise.all([
         fetchResultSet(q),
-        from ? fetchResultSet(from) : undefined,
+        Promise.all(names.map(async (name) => ({ name, data: await fetchResultSet(name) }))),
       ]);
 
-      return {
-        data,
-        borrowed: from && borrowedData ? { name: from, data: borrowedData } : undefined,
-      };
+      return { data, borrowed };
     } catch (e) {
       console.error(e);
       // SAFETY: don't care -- the fact that people can throw non-errors is a mistake

--- a/results/app/styles/app.css
+++ b/results/app/styles/app.css
@@ -532,6 +532,22 @@ table {
   max-width: 40vw;
 }
 
+/* one borrow per line: the card is a column of the settings grid, so the
+   row has to be allowed to shrink -- otherwise the longest run name sets
+   its width and the card overflows the column */
+.borrow-controls .borrow-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--gap-1) var(--gap-2);
+  flex: 1 0 100%;
+  min-width: 0;
+
+  select {
+    min-width: 0;
+  }
+}
+
 /* pulls each "remove run" button back against the selector it removes,
    undoing most of the control bar's column gap */
 .compare-controls .remove-run {

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -7,7 +7,7 @@ import { BoxPlotChart } from "@sgratzl/chartjs-chart-boxplot";
 import { converter, filterBrightness, formatCss } from "culori";
 import { modifier } from "ember-modifier";
 
-import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
+import { BorrowPicker, borrowsOf } from "#components/borrow-picker.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
 import { SortControl } from "#components/sort-control.gts";
@@ -177,7 +177,7 @@ export default class Boxplat extends Component<{
 
   @cached
   get columns() {
-    return columnsFor(this.args.model.data, this.frameworks, this.borrow);
+    return columnsFor(this.args.model.data, this.frameworks, this.borrows);
   }
 
   sorted(benches: BenchmarkInfo[]) {
@@ -203,12 +203,12 @@ export default class Boxplat extends Component<{
 
   settingParams = ["hide", "from", "sort"] as const;
 
-  get borrow() {
-    return borrowOf(this.queryParams, this.args.model.borrowed);
+  get borrows() {
+    return borrowsOf(this.queryParams, this.args.model.borrowed);
   }
 
   get rows() {
-    return this.frameworks.length + (this.borrow ? 1 : 0);
+    return this.frameworks.length + this.borrows.length;
   }
 
   get height() {

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -6,7 +6,7 @@ import { service } from "@ember/service";
 import { interpolate } from "culori";
 
 import { BenchmarkName } from "#components/benchmark-name.gts";
-import { borrowOf, BorrowPicker } from "#components/borrow-picker.gts";
+import { BorrowPicker, borrowsOf } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { Settings } from "#components/settings.gts";
@@ -432,8 +432,8 @@ export default class ResultsTables extends Component<{
     return this.args.model.data;
   }
 
-  get borrow() {
-    return borrowOf(this.queryParams, this.args.model.borrowed);
+  get borrows() {
+    return borrowsOf(this.queryParams, this.args.model.borrowed);
   }
 
   get visibleFrameworks() {
@@ -442,7 +442,7 @@ export default class ResultsTables extends Component<{
 
   @cached
   get columns() {
-    return columnsFor(this.file, this.visibleFrameworks, this.borrow);
+    return columnsFor(this.file, this.visibleFrameworks, this.borrows);
   }
 
   settingParams = ["mode", "p", "hide", "from", "sort", "curve"] as const;

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -497,43 +497,46 @@ export function borrowLabel(index: number) {
 }
 
 /**
- * The table's own columns, plus the borrowed one if a column is on loan.
+ * The table's own columns, plus one per borrowed column.
  *
- * In the recorded order the borrowed column sits directly beside the
+ * In the recorded order each borrowed column sits directly beside the
  * framework it is on loan against, so the two read as a pair. Sorting then
  * moves it on its own total like any other column.
  */
 export function columnsFor(
   file: ResultSet,
   frameworks: string[],
-  borrow: { name: string; data: ResultSet; framework: string } | undefined,
+  borrows: readonly { name: string; data: ResultSet; framework: string }[],
 ): Column[] {
-  const columns: Column[] = frameworks.map((framework) => ({
+  let columns: Column[] = frameworks.map((framework) => ({
     key: framework,
     framework,
     data: file,
   }));
 
-  if (!borrow) return columns;
+  for (const [index, borrow] of borrows.entries()) {
+    const borrowed: Column = {
+      // a borrowed column can repeat a framework the table already shows,
+      // so the run it came from has to be part of its identity
+      key: `borrowed:${borrow.name}:${borrow.framework}`,
+      framework: borrow.framework,
+      data: borrow.data,
+      borrowedFrom: borrow.name,
+      label: borrowLabel(index),
+    };
 
-  const borrowed: Column = {
-    // a borrowed column can repeat a framework the table already shows, so
-    // the run it came from has to be part of its identity
-    key: `borrowed:${borrow.name}:${borrow.framework}`,
-    framework: borrow.framework,
-    data: borrow.data,
-    borrowedFrom: borrow.name,
-    // only one borrow is possible so far; this becomes its position once
-    // several can be on loan at once
-    label: borrowLabel(0),
-  };
+    // after the last column for this framework, so two borrows of the same
+    // one land in A, B order rather than reversed
+    const counterpart = columns.findLastIndex((column) => column.framework === borrow.framework);
 
-  const counterpart = columns.findIndex((column) => column.framework === borrow.framework);
+    // the framework can be hidden, or absent from this run entirely
+    columns =
+      counterpart === -1
+        ? columns.concat(borrowed)
+        : columns.toSpliced(counterpart + 1, 0, borrowed);
+  }
 
-  // the framework can be hidden, or absent from this run entirely
-  if (counterpart === -1) return columns.concat(borrowed);
-
-  return columns.toSpliced(counterpart + 1, 0, borrowed);
+  return columns;
 }
 
 export function labelFor(percentile: Percentile) {


### PR DESCRIPTION
`?from=` and `?col=` become comma lists, positional against each other: one run and one framework per borrowed column. A single-borrow URL is just a one-element list, so existing links keep working.

```
?q=8&from=7,6,5&col=ember,angular,svelte&sort=best

┊ A     ┊         ┊           ┊ B      ┊       ┊  ┊ C      ┊
Ember   Angular   Vue Vapor    Angular  Lit ... Svelte ...
#7      (own)     (own)        #6       (own)   #5
344.7   2174.2    728.65       2384.3   1067.1  1051
```

Each borrowed column keeps its own badge, dashed brackets, and throttle warning — and each sorts on its own total. Above, A came from an unthrottled run so it warns; B is from a run at the same 8x and stays quiet; C is from a 4x run and warns.

### How

The route loads every named set in parallel and `Model.borrowed` becomes an array. `borrowsOf` returns one `Borrow` per entry, falling back to a run's first framework when the requested one is missing, so an edited URL degrades instead of dropping the column. `columnsFor` labels them A, B, C by position — what `borrowLabel` was written for — and seats each beside its own counterpart, searching from the end so two borrows of the same framework land in A, B order rather than reversed.

### Picker

A row per borrow: badge, both selects, its own remove. Plus one control to add another. Runs already on loan drop out of the other rows' options, and the add control disappears when there's nothing left to borrow.

Editing rewrites both lists together since they're positional. Trailing unchosen columns are trimmed rather than written as empty entries — adding a borrow gives `?from=7`, not `?col=&from=7`.

### Verified

Three simultaneous borrows at 1920px; add ×3 then remove the middle one (C correctly becomes B, `from=7,5` and `col` stays aligned); the picker card stays inside its settings-grid column. `pnpm lint` and `pnpm build` pass.

Rebased onto main after #102 and #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)