### PR TITLE
Sort by best total by default, and make the other option alphabetical

### DIFF
--- a/results/app/components/settings.gts
+++ b/results/app/components/settings.gts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 
-import { DEFAULT_CURVE, DEFAULT_PERCENTILE } from "#utils";
+import { DEFAULT_CURVE, DEFAULT_PERCENTILE, DEFAULT_SORT } from "#utils";
 
 import type Owner from "@ember/owner";
 import type QueryParams from "#services/query-params.ts";
@@ -10,6 +10,7 @@ const DEFAULTS: Record<string, string> = {
   mode: "raw",
   p: String(DEFAULT_PERCENTILE),
   curve: String(DEFAULT_CURVE),
+  sort: DEFAULT_SORT,
 };
 
 function hasNonDefaults(qp: QueryParams, params: readonly string[]) {

--- a/results/app/components/sort-control.gts
+++ b/results/app/components/sort-control.gts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 
-import { totalSortFrom } from "#utils";
+import { DEFAULT_SORT, totalSortFrom } from "#utils";
 
 import type RouterService from "@ember/routing/router-service";
 import type QueryParams from "#services/query-params.ts";
@@ -11,24 +11,16 @@ export class SortControl extends Component {
   @service declare router: RouterService;
   @service declare queryParams: QueryParams;
 
-  isSort = (sort: TotalSort | undefined) => totalSortFrom(this.queryParams) === sort;
+  isSort = (sort: TotalSort) => totalSortFrom(this.queryParams) === sort;
 
-  setSort = (sort: TotalSort | null) => {
-    this.router.transitionTo({ queryParams: { sort } });
+  setSort = (sort: TotalSort) => {
+    // the default stays out of the URL
+    this.router.transitionTo({ queryParams: { sort: sort === DEFAULT_SORT ? null : sort } });
   };
 
   <template>
     <fieldset class="value-mode surface">
       <legend>sort</legend>
-      <label>
-        <input
-          type="radio"
-          name="total-sort"
-          checked={{this.isSort undefined}}
-          {{on "change" (fn this.setSort null)}}
-        />
-        default order
-      </label>
       <label>
         <input
           type="radio"
@@ -46,6 +38,15 @@ export class SortControl extends Component {
           {{on "change" (fn this.setSort "worst")}}
         />
         worst total first
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="total-sort"
+          checked={{this.isSort "alphabetical"}}
+          {{on "change" (fn this.setSort "alphabetical")}}
+        />
+        alphabetical
       </label>
       <span class="units">within each result area</span>
     </fieldset>

--- a/results/app/templates/results/boxplot.gts
+++ b/results/app/templates/results/boxplot.gts
@@ -181,11 +181,12 @@ export default class Boxplat extends Component<{
   }
 
   sorted(benches: BenchmarkInfo[]) {
-    const sort = totalSortFrom(this.queryParams);
-
-    if (!sort) return this.columns;
-
-    return sortedByTotal(this.columns, benches, percentileFrom(this.queryParams), sort);
+    return sortedByTotal(
+      this.columns,
+      benches,
+      percentileFrom(this.queryParams),
+      totalSortFrom(this.queryParams),
+    );
   }
 
   @cached

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -462,11 +462,7 @@ export default class ResultsTables extends Component<{
   }
 
   sorted(benches: BenchmarkInfo[]) {
-    const sort = totalSortFrom(this.queryParams);
-
-    if (!sort) return this.columns;
-
-    return sortedByTotal(this.columns, benches, this.percentile, sort);
+    return sortedByTotal(this.columns, benches, this.percentile, totalSortFrom(this.queryParams));
   }
 
   @cached

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -2,7 +2,7 @@ import { assert, warn } from "@ember/debug";
 
 import { experiments, metadata } from "virtual:result-sets";
 
-import { frameworks } from "./frameworks.ts";
+import { frameworks, nameOf } from "./frameworks.ts";
 
 import type QueryParams from "#services/query-params.ts";
 import type { BenchmarkInfo, Column, Mark, ResultData, ResultSet } from "#types";
@@ -431,25 +431,31 @@ export function curveFrom(qp: QueryParams): number {
   return Number.isFinite(curve) ? curve : DEFAULT_CURVE;
 }
 
-export type TotalSort = "best" | "worst";
+export type TotalSort = "best" | "worst" | "alphabetical";
+
+export const DEFAULT_SORT: TotalSort = "best";
 
 /**
  * The `?sort=` query param, wherever a component needs it.
- * Absent (or anything unrecognized) means the recorded order.
+ *
+ * Absent (or anything unrecognized) is best-first: the question the tables
+ * exist to answer is which framework won, and answering it should not need
+ * a setting.
  */
-export function totalSortFrom(qp: QueryParams): TotalSort | undefined {
+export function totalSortFrom(qp: QueryParams): TotalSort {
   const sort = qp.get("sort");
 
-  return sort === "best" || sort === "worst" ? sort : undefined;
+  return sort === "worst" || sort === "alphabetical" || sort === "best" ? sort : DEFAULT_SORT;
 }
 
 /**
- * Columns ordered by their summed result over one area's benches.
+ * Columns in the order the reader asked for.
  *
  * "best" and "worst" are stated in the area's own direction -- best-first
  * is the highest total when bigger is better and the lowest when smaller
  * is -- so the same setting reads coherently across both areas. Columns
- * with no data for the area go last either way.
+ * with no data for the area go last either way. "alphabetical" ignores the
+ * numbers and orders by displayed name.
  *
  * Each column carries the run it reads from, so a borrowed column sorts on
  * its own numbers rather than being pinned to one end.
@@ -460,6 +466,10 @@ export function sortedByTotal(
   percentile: Percentile,
   sort: TotalSort,
 ) {
+  if (sort === "alphabetical") {
+    return columns.toSorted((a, b) => nameOf(a.framework).localeCompare(nameOf(b.framework)));
+  }
+
   const totals = new Map<string, number>();
 
   for (const column of columns) {


### PR DESCRIPTION
Which framework won is the question the tables exist to answer, so they should answer it without being asked. `?sort=` absent now means best-first, and choosing best-first writes nothing to the URL.

### On the relabel

The option being displaced as the default was labelled **"default order"** — the order the runner happened to record frameworks in:

```
angular, ember, lit-signals, preact, react, solid-1, solid-2, svelte, vue-vapor, vue
```

That's alphabetical *except* `vue-vapor`, which the recorded order puts ahead of `vue`. So relabelling it "alphabetical" on its own would have made the label wrong. It now actually sorts on the displayed name — the same `nameOf(a).localeCompare(nameOf(b))` the compare page already uses — and **Vue.js precedes Vue.js Vapor**:

| | order |
| --- | --- |
| was ("default order") | … Svelte, **Vue.js Vapor, Vue.js** |
| now ("alphabetical") | … Svelte, **Vue.js, Vue.js Vapor** |

If you only wanted the label swapped and are happy for it to stay in recorded order, that's a one-line revert of the sort branch.

### Shape

`sortedByTotal` grew the third case rather than the callers branching around it, so `index.gts` and `boxplot.gts` just always sort — the `if (!sort) return this.columns` early-out is gone from both. `DEFAULT_SORT` is registered in the settings `DEFAULTS` map, so arriving at the default no longer springs the settings panel open.

### Verified

At 1920px: default (no param) produces exactly the ordering the old explicit `sort=best` did, `alphabetical` and `worst` both correct, the settings panel stays collapsed at the default and the three radios render with the right one checked. `pnpm lint` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)