### PR TITLE
Add the settings UI to the Animated tab

### DIFF
--- a/results/app/components/percentile-control.gts
+++ b/results/app/components/percentile-control.gts
@@ -1,0 +1,43 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { labelFor, percentileFrom, PERCENTILES } from "#utils";
+
+import type RouterService from "@ember/routing/router-service";
+import type QueryParams from "#services/query-params.ts";
+import type { Percentile } from "#utils";
+
+export class PercentileControl extends Component {
+  @service declare router: RouterService;
+  @service declare queryParams: QueryParams;
+
+  percentiles = PERCENTILES;
+
+  isPercentile = (percentile: Percentile) => percentileFrom(this.queryParams) === percentile;
+
+  setPercentile = (percentile: Percentile) => {
+    this.router.transitionTo({ queryParams: { p: percentile } });
+  };
+
+  labelFor = labelFor;
+
+  <template>
+    <fieldset class="value-mode surface">
+      <legend>statistic</legend>
+      {{#each this.percentiles as |percentile|}}
+        <label>
+          <input
+            type="radio"
+            name="percentile"
+            checked={{this.isPercentile percentile}}
+            {{on "change" (fn this.setPercentile percentile)}}
+          />
+          {{this.labelFor percentile}}
+        </label>
+      {{/each}}
+      {{! percentiles run toward the worse end either way, so the same
+        number means the same thing on both tables }}
+      <span class="units">of each run's samples</span>
+    </fieldset>
+  </template>
+}

--- a/results/app/templates/results/animated.gts
+++ b/results/app/templates/results/animated.gts
@@ -4,6 +4,9 @@ import { assert } from "@ember/debug";
 import { service } from "@ember/service";
 
 import { FrameworkInfo } from "#components/framework-info.gts";
+import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
+import { PercentileControl } from "#components/percentile-control.gts";
+import { Settings } from "#components/settings.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import { dataOf, percentileFrom, round, variantOf } from "#utils";
@@ -27,12 +30,30 @@ export default class Animated extends Component<{
       .toSorted((a, b) => (a.name.includes("async") ? 1 : 0) - (b.name.includes("async") ? 1 : 0));
   }
 
+  // sort and borrows are column concepts; this view already orders its
+  // rows by speed, so only the row-level settings apply
+  settingParams = ["p", "hide"] as const;
+
+  resultsFor = (benchInfo: BenchmarkInfo) => {
+    const visible = visibleFrameworksOf(this.queryParams, this.args.model.data);
+
+    return dataOf(this.args.model.data.results, benchInfo.name, this.percentile).filter((result) =>
+      visible.includes(result.name),
+    );
+  };
+
   <template>
+    <Settings @params={{this.settingParams}}>
+      <PercentileControl />
+
+      <FrameworkToggles @file={{@model.data}} />
+    </Settings>
+
     {{#each this.benchmarkInfo as |benchInfo|}}
       <Visualize
         @benchInfo={{benchInfo}}
         @file={{@model.data}}
-        @results={{dataOf @model.data.results benchInfo.name this.percentile}}
+        @results={{this.resultsFor benchInfo}}
       />
     {{/each}}
   </template>

--- a/results/app/templates/results/animated.gts
+++ b/results/app/templates/results/animated.gts
@@ -3,17 +3,34 @@ import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { service } from "@ember/service";
 
+import { BorrowPicker, borrowsOf } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
 import { PercentileControl } from "#components/percentile-control.gts";
 import { Settings } from "#components/settings.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
-import { dataOf, percentileFrom, round, variantOf } from "#utils";
+import { frameworks } from "#frameworks";
+import {
+  columnsFor,
+  formatRunName,
+  overrideOf,
+  percentileFrom,
+  round,
+  timeFor,
+  variantOf,
+  versionOf,
+} from "#utils";
 
 import type { Model } from "#routes/results.ts";
 import type QueryParams from "#services/query-params.ts";
-import type { BenchmarkInfo, Results, ResultSet } from "#types";
+import type { BenchmarkInfo, Column } from "#types";
+
+/** One racer: where its time came from, and the time itself. */
+interface Row {
+  column: Column;
+  speed: number;
+}
 
 export default class Animated extends Component<{
   model: Model;
@@ -30,16 +47,35 @@ export default class Animated extends Component<{
       .toSorted((a, b) => (a.name.includes("async") ? 1 : 0) - (b.name.includes("async") ? 1 : 0));
   }
 
-  // sort and borrows are column concepts; this view already orders its
-  // rows by speed, so only the row-level settings apply
-  settingParams = ["p", "hide"] as const;
+  // no sort control: the rows already order themselves by measured speed
+  settingParams = ["p", "hide", "from"] as const;
 
-  resultsFor = (benchInfo: BenchmarkInfo) => {
-    const visible = visibleFrameworksOf(this.queryParams, this.args.model.data);
+  get borrows() {
+    return borrowsOf(this.queryParams, this.args.model.borrowed);
+  }
 
-    return dataOf(this.args.model.data.results, benchInfo.name, this.percentile).filter((result) =>
-      visible.includes(result.name),
+  @cached
+  get columns() {
+    return columnsFor(
+      this.args.model.data,
+      visibleFrameworksOf(this.queryParams, this.args.model.data),
+      this.borrows,
     );
+  }
+
+  rowsFor = (benchInfo: BenchmarkInfo): Row[] => {
+    const rows: Row[] = [];
+
+    for (const column of this.columns) {
+      // a borrowed run doesn't necessarily cover every benchmark
+      const speed = timeFor(column.data, column.framework, benchInfo, this.percentile);
+
+      if (speed === undefined) continue;
+
+      rows.push({ column, speed });
+    }
+
+    return rows;
   };
 
   <template>
@@ -47,20 +83,18 @@ export default class Animated extends Component<{
       <PercentileControl />
 
       <FrameworkToggles @file={{@model.data}} />
+
+      <BorrowPicker @borrowed={{@model.borrowed}} />
     </Settings>
 
     {{#each this.benchmarkInfo as |benchInfo|}}
-      <Visualize
-        @benchInfo={{benchInfo}}
-        @file={{@model.data}}
-        @results={{this.resultsFor benchInfo}}
-      />
+      <Visualize @benchInfo={{benchInfo}} @rows={{this.rowsFor benchInfo}} />
     {{/each}}
   </template>
 }
 
-function scaleFactor(results: Results) {
-  const fastest = results[0];
+function scaleFactor(rows: Row[]) {
+  const fastest = rows[0];
 
   assert(`Results are empty`, fastest);
 
@@ -69,8 +103,8 @@ function scaleFactor(results: Results) {
   return (ms: number) => ms / scale;
 }
 
-function scaleFromBigger(results: Results) {
-  const max = Math.max(...results.map((r) => r.speed));
+function scaleFromBigger(rows: Row[]) {
+  const max = Math.max(...rows.map((r) => r.speed));
 
   assert(`Results are empty`, max);
 
@@ -82,44 +116,43 @@ function scaleFromBigger(results: Results) {
   };
 }
 
-function sortBigger(results: Results) {
-  return results.toSorted((a, b) => b.speed - a.speed);
+function sortBigger(rows: Row[]) {
+  return rows.toSorted((a, b) => b.speed - a.speed);
 }
 
-function sortSmaller(results: Results) {
-  return results.toSorted((a, b) => a.speed - b.speed);
+function sortSmaller(rows: Row[]) {
+  return rows.toSorted((a, b) => a.speed - b.speed);
+}
+
+function colorOf(framework: string) {
+  return frameworks[framework]?.color ?? "#888";
 }
 
 export class Visualize extends Component<{
   benchInfo: BenchmarkInfo;
-  results: Results;
-  file: ResultSet;
+  rows: Row[];
 }> {
   @cached
   get scaleTime() {
     if (this.args.benchInfo.whatsBetter === "bigger") {
-      return scaleFromBigger(this.args.results);
+      return scaleFromBigger(this.args.rows);
     }
 
-    return scaleFactor(this.args.results);
+    return scaleFactor(this.args.rows);
   }
 
   @cached
   get sorted() {
     if (this.args.benchInfo.whatsBetter === "bigger") {
-      return sortBigger(this.args.results);
+      return sortBigger(this.args.rows);
     }
 
-    return sortSmaller(this.args.results);
+    return sortSmaller(this.args.rows);
   }
 
   get isBiggerBetter() {
     return this.args.benchInfo.whatsBetter === "bigger";
   }
-
-  overrideFor = (framework: string) => {
-    return this.args.file.versionOverrides?.[framework];
-  };
 
   <template>
     <section class="languages-container">
@@ -135,27 +168,38 @@ export class Visualize extends Component<{
         <thead></thead>
 
         <tbody>
-          {{#each this.sorted as |fw|}}
+          {{#each this.sorted key="column.key" as |row|}}
             <tr>
               <td>
-                <FrameworkInfo @name={{fw.name}} />
-                <Variant @variant={{variantOf @file fw.name}} />
+                {{#if row.column.borrowedFrom}}
+                  {{! which borrow this is; the run it names is spelled out on
+                      the borrow picker, so the row only carries the letter }}
+                  <span
+                    class="borrow-label"
+                    title="borrowed from {{formatRunName row.column.borrowedFrom}}"
+                  >{{row.column.label}}</span>
+                {{/if}}
+                <FrameworkInfo @name={{row.column.framework}} />
+                <Variant @variant={{variantOf row.column.data row.column.framework}} />
               </td>
-              <td class="time">{{round fw.speed}}
-                {{fw.units}}
+              <td class="time">{{round row.speed}}
+                {{@benchInfo.units}}
                 <br />
                 <span class="small">
-                  <Version @version={{fw.version}} @override={{this.overrideFor fw.name}} />
+                  <Version
+                    @version={{versionOf row.column.data row.column.framework}}
+                    @override={{overrideOf row.column.data row.column.framework}}
+                  />
                 </span>
               </td>
               <td>
                 <svg width="100%" height="48" viewBox="0 0 400 48">
-                  <circle cx="50" cy="24" r="10" fill={{fw.color}}>
+                  <circle cx="50" cy="24" r="10" fill={{colorOf row.column.framework}}>
                     <animate
                       attributeName="cx"
                       values="50; 350; 50"
                       keyTimes="0; 0.5; 1"
-                      dur="{{this.scaleTime fw.speed}}s"
+                      dur="{{this.scaleTime row.speed}}s"
                       repeatCount="indefinite"
                     />
                   </circle>
@@ -170,6 +214,11 @@ export class Visualize extends Component<{
     <style>
       tr td {
         border-bottom: 1px solid lightgray;
+      }
+      /* anchors the absolutely-positioned borrow badge to its row's
+         framework cell, the way the results table's headers do */
+      tr td:first-child {
+        position: relative;
       }
       .time {
         font-style: italic;

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -9,6 +9,7 @@ import { BenchmarkName } from "#components/benchmark-name.gts";
 import { BorrowPicker, borrowsOf } from "#components/borrow-picker.gts";
 import { FrameworkInfo } from "#components/framework-info.gts";
 import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-toggles.gts";
+import { PercentileControl } from "#components/percentile-control.gts";
 import { Settings } from "#components/settings.gts";
 import { SortControl } from "#components/sort-control.gts";
 import { Variant } from "#components/variant.gts";
@@ -24,7 +25,6 @@ import {
   lowerIsBetterBenches,
   overrideOf,
   percentileFrom,
-  PERCENTILES,
   round,
   sortedByTotal,
   throttleLabel,
@@ -397,17 +397,9 @@ export default class ResultsTables extends Component<{
 
   isMode = (mode: ValueMode) => this.mode === mode;
 
-  percentiles = PERCENTILES;
-
   get percentile(): Percentile {
     return percentileFrom(this.queryParams);
   }
-
-  setPercentile = (percentile: Percentile) => {
-    this.router.transitionTo({ queryParams: { p: percentile } });
-  };
-
-  isPercentile = (percentile: Percentile) => this.percentile === percentile;
 
   get curve() {
     return curveFrom(this.queryParams);
@@ -426,8 +418,6 @@ export default class ResultsTables extends Component<{
       queryParams: { curve: valueAsNumber === DEFAULT_CURVE ? null : valueAsNumber },
     });
   };
-
-  labelFor = labelFor;
 
   get file() {
     return this.args.model.data;
@@ -521,23 +511,7 @@ export default class ResultsTables extends Component<{
         </label>
       </fieldset>
 
-      <fieldset class="value-mode surface">
-        <legend>statistic</legend>
-        {{#each this.percentiles as |percentile|}}
-          <label>
-            <input
-              type="radio"
-              name="percentile"
-              checked={{this.isPercentile percentile}}
-              {{on "change" (fn this.setPercentile percentile)}}
-            />
-            {{this.labelFor percentile}}
-          </label>
-        {{/each}}
-        {{! percentiles run toward the worse end either way, so the same
-          number means the same thing on both tables }}
-        <span class="units">of each run's samples</span>
-      </fieldset>
+      <PercentileControl />
 
       <fieldset class="value-mode surface">
         <legend>color curve</legend>


### PR DESCRIPTION
The Animated tab was the only results view without the settings panel. It now has one, with:

- **statistic** (p50/p75/p90): the tab already read `?p=` for its numbers; now it's changeable from the page.
- **frameworks**: hiding a framework removes its rows, and the bubble speeds rescale against the visible set.
- **borrow columns**: the tab now builds its rows through the same column model as the Table and Boxplot, so a borrowed run's framework races alongside the current run's, sorted into place by its own speed and badged with the borrow letter (tooltip names the run).

The statistic picker is extracted from the Table template into a shared `PercentileControl` component (same shape as `SortControl`), so both tabs render the same fieldset.

The sort control stays Table/Boxplot-only: this view already orders its rows by measured speed, so it would have nothing to act on.

Verified in the dev server: `?p=`, `?hide=`, and `?from=`/`?col=` all round-trip through the URL on the Animated tab, and the Table tab's statistic control still works after the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)