### PR TITLE
Let the reader split the milliseconds table

### DIFF
--- a/results/app/components/table-splits.gts
+++ b/results/app/components/table-splits.gts
@@ -1,0 +1,54 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { splitOptionsOf } from "#utils";
+
+import type RouterService from "@ember/routing/router-service";
+import type QueryParams from "#services/query-params.ts";
+import type { BenchmarkInfo } from "#types";
+
+export function splitsFrom(qp: QueryParams) {
+  const split = qp.get("split");
+
+  return split ? split.split(",") : [];
+}
+
+export class TableSplits extends Component<{
+  benchmarkInfo: BenchmarkInfo[];
+}> {
+  @service declare router: RouterService;
+  @service declare queryParams: QueryParams;
+
+  get options() {
+    return splitOptionsOf(this.args.benchmarkInfo);
+  }
+
+  isSplit = (token: string) => splitsFrom(this.queryParams).includes(token);
+
+  toggle = (token: string, event: Event) => {
+    const { checked } = event.target as HTMLInputElement;
+    const splits = splitsFrom(this.queryParams).filter((entry) => entry !== token);
+
+    if (checked) splits.push(token);
+
+    this.router.transitionTo({ queryParams: { split: splits.join(",") || null } });
+  };
+
+  <template>
+    <fieldset class="value-mode surface">
+      <legend>split tables</legend>
+      {{#each this.options as |token|}}
+        <label>
+          <input
+            type="checkbox"
+            name="split-{{token}}"
+            checked={{this.isSplit token}}
+            {{on "change" (fn this.toggle token)}}
+          />
+          {{token}}
+        </label>
+      {{/each}}
+      <span class="units">checked benchmarks move to their own table</span>
+    </fieldset>
+  </template>
+}

--- a/results/app/routes/results.ts
+++ b/results/app/routes/results.ts
@@ -44,6 +44,9 @@ export default class Results extends Route<Model> {
     // which percentile of each run's samples to show (50 | 75 | 90);
     // every sample is already loaded, so no model impact
     p: {},
+    // comma-separated: which bench groups get their own milliseconds
+    // table; purely layout, so no model impact
+    split: {},
   };
 
   beforeModel(transition: Transition) {

--- a/results/app/templates/results/index.gts
+++ b/results/app/templates/results/index.gts
@@ -12,17 +12,17 @@ import { FrameworkToggles, visibleFrameworksOf } from "#components/framework-tog
 import { PercentileControl } from "#components/percentile-control.gts";
 import { Settings } from "#components/settings.gts";
 import { SortControl } from "#components/sort-control.gts";
+import { splitsFrom, TableSplits } from "#components/table-splits.gts";
 import { Variant } from "#components/variant.gts";
 import { Version } from "#components/version.gts";
 import {
   columnsFor,
   curveFrom,
   DEFAULT_CURVE,
-  effectsBenches,
   formatRunName,
   higherIsBetterBenches,
   labelFor,
-  lowerIsBetterBenches,
+  msBenchGroups,
   overrideOf,
   percentileFrom,
   round,
@@ -436,7 +436,7 @@ export default class ResultsTables extends Component<{
     return columnsFor(this.file, this.visibleFrameworks, this.borrows);
   }
 
-  settingParams = ["mode", "p", "hide", "from", "sort", "curve"] as const;
+  settingParams = ["mode", "p", "hide", "from", "sort", "curve", "split"] as const;
 
   get benchmarkInfo() {
     return this.args.model.data.benchmarkInfo;
@@ -445,16 +445,6 @@ export default class ResultsTables extends Component<{
   @cached
   get higherBenches() {
     return higherIsBetterBenches(this.benchmarkInfo);
-  }
-
-  @cached
-  get lowerBenches() {
-    return lowerIsBetterBenches(this.benchmarkInfo);
-  }
-
-  @cached
-  get effectBenches() {
-    return effectsBenches(this.benchmarkInfo);
   }
 
   sorted(benches: BenchmarkInfo[]) {
@@ -466,14 +456,17 @@ export default class ResultsTables extends Component<{
     return this.sorted(this.higherBenches);
   }
 
+  /**
+   * The millisecond tables the reader asked for -- one by default, plus
+   * one per checked split -- each sorted on its own totals.
+   */
   @cached
-  get lowerColumns() {
-    return this.sorted(this.lowerBenches);
-  }
-
-  @cached
-  get effectColumns() {
-    return this.sorted(this.effectBenches);
+  get msGroups() {
+    return msBenchGroups(this.benchmarkInfo, splitsFrom(this.queryParams)).map((group) => ({
+      heading: group.heading,
+      benches: group.benches,
+      columns: this.sorted(group.benches),
+    }));
   }
 
   <template>
@@ -530,6 +523,8 @@ export default class ResultsTables extends Component<{
 
       <SortControl />
 
+      <TableSplits @benchmarkInfo={{this.benchmarkInfo}} />
+
       <FrameworkToggles @file={{this.file}} />
 
       <BorrowPicker @borrowed={{@model.borrowed}} />
@@ -544,22 +539,13 @@ export default class ResultsTables extends Component<{
       <br />
     {{/if}}
 
-    {{#if this.lowerBenches.length}}
-      <h2>lower is better</h2>
+    {{#each this.msGroups key="heading" as |group|}}
+      <h2>{{group.heading}}</h2>
 
-      <Table @benches={{this.lowerBenches}} @file={{this.file}} @columns={{this.lowerColumns}} />
+      <Table @benches={{group.benches}} @file={{this.file}} @columns={{group.columns}} />
       <br />
       <br />
       <br />
-    {{/if}}
-
-    {{#if this.effectBenches.length}}
-      <h2>effects (lower is better)</h2>
-
-      <Table @benches={{this.effectBenches}} @file={{this.file}} @columns={{this.effectColumns}} />
-      <br />
-      <br />
-      <br />
-    {{/if}}
+    {{/each}}
   </template>
 }

--- a/results/app/utils.ts
+++ b/results/app/utils.ts
@@ -573,11 +573,90 @@ export function effectsBenches(benchmarkInfo: BenchmarkInfo[]) {
   return benchmarkInfo.filter((bench) => isEffectsBench(bench));
 }
 
-export function lowerIsBetterBenches(benchmarkInfo: BenchmarkInfo[]) {
+/**
+ * Every millisecond bench, effects included, with the async variants
+ * reading below their synchronous counterparts.
+ */
+export function msBenches(benchmarkInfo: BenchmarkInfo[]) {
   return benchmarkInfo
-    .filter((bench) => bench.whatsBetter !== "bigger" && !isEffectsBench(bench))
-    .toSorted()
+    .filter((bench) => bench.whatsBetter !== "bigger")
     .toSorted((a, b) => (a.name.includes("async") ? 1 : 0) - (b.name.includes("async") ? 1 : 0));
+}
+
+export function lowerIsBetterBenches(benchmarkInfo: BenchmarkInfo[]) {
+  return msBenches(benchmarkInfo).filter((bench) => !isEffectsBench(bench));
+}
+
+/**
+ * The `?split=` token that would carve this bench out of the main
+ * milliseconds table: `effects` for the effects section, the bench's app
+ * for everything else. The effects benches answer only to `effects` --
+ * they are one group whatever apps they span.
+ */
+function splitTokenOf(bench: BenchmarkInfo) {
+  return isEffectsBench(bench) ? "effects" : bench.app;
+}
+
+/**
+ * One summary table's worth of milliseconds benches.
+ */
+export interface BenchGroup {
+  /** the `?split=` token that carved this group out; undefined for the main table */
+  token?: string;
+  heading: string;
+  benches: BenchmarkInfo[];
+}
+
+/**
+ * The milliseconds benches, dealt into one table per checked `?split=`
+ * token. Everything unchecked stays together in the main table, which
+ * always reads first; the split-out tables follow in bench order.
+ */
+export function msBenchGroups(
+  benchmarkInfo: BenchmarkInfo[],
+  splits: readonly string[],
+): BenchGroup[] {
+  const main: BenchGroup = { heading: "lower is better", benches: [] };
+  const carved = new Map<string, BenchGroup>();
+
+  for (const bench of msBenches(benchmarkInfo)) {
+    const token = splitTokenOf(bench);
+
+    if (!splits.includes(token)) {
+      main.benches.push(bench);
+      continue;
+    }
+
+    const group = carved.get(token) ?? {
+      token,
+      heading: `${token} (lower is better)`,
+      benches: [],
+    };
+
+    group.benches.push(bench);
+    carved.set(token, group);
+  }
+
+  const groups: BenchGroup[] = main.benches.length ? [main] : [];
+
+  return groups.concat(Array.from(carved.values()));
+}
+
+/**
+ * The tokens `?split=` answers to for a run, in bench order: `effects`
+ * when the run has any effects benches, plus one per app. What the split
+ * checkboxes offer.
+ */
+export function splitOptionsOf(benchmarkInfo: BenchmarkInfo[]) {
+  const options: string[] = [];
+
+  for (const bench of msBenches(benchmarkInfo)) {
+    const token = splitTokenOf(bench);
+
+    if (!options.includes(token)) options.push(token);
+  }
+
+  return options;
 }
 
 export function dataOf(results: ResultData, benchName: string, percentile: Percentile) {


### PR DESCRIPTION
By default, every millisecond bench now reads from one lower-is-better table, effects included in its rows and Total.

A new **split tables** checkbox group in settings (`?split=`, comma-separated) carves groups back out into their own tables:

- **effects** restores the separate "effects (lower is better)" section
- each benchmark app (`one-item-many-updates`, `ten-k-items-one-time`, `fan-out`) can be split out the same way

Each table sorts and totals on its own benches, single-row tables skip the Total row, and settings auto-opens when a split is active. The compare and boxplot pages keep their existing grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)