### PR TITLE
Bump solid-2 apps to 2.0.0-rc.3

### DIFF
--- a/frameworks/solid-2/dbmon-with-chat/package.json
+++ b/frameworks/solid-2/dbmon-with-chat/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.27"
+    "@solidjs/vite-plugin": "3.0.0-next.34"
   }
 }

--- a/frameworks/solid-2/dbmon-with-chat/package.json
+++ b/frameworks/solid-2/dbmon-with-chat/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.27",
+    "@solidjs/web": "2.0.0-rc.3",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.27"
+    "solid-js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.17"
+    "vite-plugin-solid": "3.0.0-next.27"
   }
 }

--- a/frameworks/solid-2/dbmon-with-chat/pnpm-lock.yaml
+++ b/frameworks/solid-2/dbmon-with-chat/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
@@ -27,9 +30,6 @@ importers:
       vite:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.27
-        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
 
 packages:
 
@@ -118,59 +118,23 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
-    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -451,11 +415,50 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/vite-plugin@3.0.0-next.32':
-    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -491,15 +494,6 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  babel-preset-solid@2.0.0-rc.2:
-    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.2
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   baseline-browser-mapping@2.8.26:
     resolution: {integrity: sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==}
@@ -742,9 +736,6 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.27:
-    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
-
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -917,56 +908,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -975,12 +925,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1089,10 +1044,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -1149,16 +1104,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
   '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.28.5)
+      '@solidjs/compiler': 2.0.0-rc.3
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
       solid-js: 2.0.0-rc.3
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
@@ -1201,13 +1197,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1420,17 +1409,6 @@ snapshots:
       picocolors: 1.1.1
 
   validate-html-nesting@1.2.4: {}
-
-  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3)):
-    dependencies:
-      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
-    transitivePeerDependencies:
-      - '@solidjs/start-devtools'
-      - '@solidjs/web'
-      - '@testing-library/jest-dom'
-      - solid-js
-      - supports-color
-      - vite
 
   vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3):
     dependencies:

--- a/frameworks/solid-2/dbmon-with-chat/pnpm-lock.yaml
+++ b/frameworks/solid-2/dbmon-with-chat/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.17
-        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
+        specifier: 3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
 
 packages:
 
@@ -118,44 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
-    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
-    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
+    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
-    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
+    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
-    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
+    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
-    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
+    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.31':
-    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
+  '@dom-expressions/compiler@0.50.0-next.44':
+    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -451,13 +451,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.27':
-    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.27':
-    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
+  '@solidjs/vite-plugin@3.0.0-next.32':
+    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      solid-js: ^2.0.0-beta.27
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -477,11 +492,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.27:
-    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.27
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -696,8 +711,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.27:
-    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -727,16 +742,8 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.17:
-    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
+  vite-plugin-solid@3.0.0-next.27:
+    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -910,7 +917,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -920,36 +927,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.31':
+  '@dom-expressions/compiler@0.50.0-next.44':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -1142,13 +1149,28 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.27': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
+  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.28.5
+      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.3
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
+      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1180,12 +1202,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1370,9 +1392,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.27:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.27
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1399,20 +1421,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3)):
+  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3)):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.31
-      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.27
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.27.3)
-      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
+      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3))
     transitivePeerDependencies:
+      - '@solidjs/start-devtools'
+      - '@solidjs/web'
+      - '@testing-library/jest-dom'
+      - solid-js
       - supports-color
+      - vite
 
   vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.3):
     dependencies:

--- a/frameworks/solid-2/dbmon-with-chat/vite.config.ts
+++ b/frameworks/solid-2/dbmon-with-chat/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, searchForWorkspaceRoot } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   // the linked `common` package lives outside this app's root; without this,

--- a/frameworks/solid-2/fan-out/package.json
+++ b/frameworks/solid-2/fan-out/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.27"
+    "@solidjs/vite-plugin": "3.0.0-next.34"
   }
 }

--- a/frameworks/solid-2/fan-out/package.json
+++ b/frameworks/solid-2/fan-out/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.27",
+    "@solidjs/web": "2.0.0-rc.3",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.27"
+    "solid-js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.17"
+    "vite-plugin-solid": "3.0.0-next.27"
   }
 }

--- a/frameworks/solid-2/fan-out/pnpm-lock.yaml
+++ b/frameworks/solid-2/fan-out/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.17
-        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,44 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
-    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
-    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
+    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
-    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
+    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
-    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
+    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
-    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
+    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.31':
-    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
+  '@dom-expressions/compiler@0.50.0-next.44':
+    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -295,13 +295,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.27':
-    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.27':
-    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
+  '@solidjs/vite-plugin@3.0.0-next.32':
+    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      solid-js: ^2.0.0-beta.27
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -321,11 +336,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.27:
-    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.27
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -535,8 +550,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.27:
-    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -566,16 +581,8 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.17:
-    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
+  vite-plugin-solid@3.0.0-next.27:
+    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -749,7 +756,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -759,36 +766,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.31':
+  '@dom-expressions/compiler@0.50.0-next.44':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -903,13 +910,28 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.27': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
+  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.28.5
+      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.3
+      vite: 8.1.5(@types/node@24.13.3)
+      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -941,12 +963,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1101,9 +1123,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.27:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.27
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1130,20 +1152,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.31
-      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.27
-      vite: 8.1.5(@types/node@24.13.3)
-      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:
+      - '@solidjs/start-devtools'
+      - '@solidjs/web'
+      - '@testing-library/jest-dom'
+      - solid-js
       - supports-color
+      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/fan-out/pnpm-lock.yaml
+++ b/frameworks/solid-2/fan-out/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
@@ -27,9 +30,6 @@ importers:
       vite:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.27
-        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,59 +118,23 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
-    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -295,11 +259,50 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/vite-plugin@3.0.0-next.32':
-    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -335,15 +338,6 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  babel-preset-solid@2.0.0-rc.2:
-    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.2
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   baseline-browser-mapping@2.8.26:
     resolution: {integrity: sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==}
@@ -581,9 +575,6 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.27:
-    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
-
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -756,56 +747,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -814,12 +764,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -850,10 +805,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -910,16 +865,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
   '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.28.5)
+      '@solidjs/compiler': 2.0.0-rc.3
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
       solid-js: 2.0.0-rc.3
       vite: 8.1.5(@types/node@24.13.3)
@@ -962,13 +958,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1151,17 +1140,6 @@ snapshots:
       picocolors: 1.1.1
 
   validate-html-nesting@1.2.4: {}
-
-  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
-    dependencies:
-      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
-    transitivePeerDependencies:
-      - '@solidjs/start-devtools'
-      - '@solidjs/web'
-      - '@testing-library/jest-dom'
-      - solid-js
-      - supports-color
-      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/fan-out/vite.config.ts
+++ b/frameworks/solid-2/fan-out/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/frameworks/solid-2/incrementing-render-effect/package.json
+++ b/frameworks/solid-2/incrementing-render-effect/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.27"
+    "@solidjs/vite-plugin": "3.0.0-next.34"
   }
 }

--- a/frameworks/solid-2/incrementing-render-effect/package.json
+++ b/frameworks/solid-2/incrementing-render-effect/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.27",
+    "@solidjs/web": "2.0.0-rc.3",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.27"
+    "solid-js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.17"
+    "vite-plugin-solid": "3.0.0-next.27"
   }
 }

--- a/frameworks/solid-2/incrementing-render-effect/pnpm-lock.yaml
+++ b/frameworks/solid-2/incrementing-render-effect/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.17
-        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,44 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
-    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
-    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
+    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
-    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
+    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
-    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
+    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
-    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
+    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.31':
-    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
+  '@dom-expressions/compiler@0.50.0-next.44':
+    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -295,13 +295,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.27':
-    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.27':
-    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
+  '@solidjs/vite-plugin@3.0.0-next.32':
+    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      solid-js: ^2.0.0-beta.27
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -321,11 +336,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.27:
-    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.27
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -535,8 +550,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.27:
-    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -566,16 +581,8 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.17:
-    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
+  vite-plugin-solid@3.0.0-next.27:
+    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -749,7 +756,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -759,36 +766,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.31':
+  '@dom-expressions/compiler@0.50.0-next.44':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -903,13 +910,28 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.27': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
+  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.28.5
+      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.3
+      vite: 8.1.5(@types/node@24.13.3)
+      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -941,12 +963,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1101,9 +1123,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.27:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.27
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1130,20 +1152,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.31
-      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.27
-      vite: 8.1.5(@types/node@24.13.3)
-      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:
+      - '@solidjs/start-devtools'
+      - '@solidjs/web'
+      - '@testing-library/jest-dom'
+      - solid-js
       - supports-color
+      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/incrementing-render-effect/pnpm-lock.yaml
+++ b/frameworks/solid-2/incrementing-render-effect/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
@@ -27,9 +30,6 @@ importers:
       vite:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.27
-        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,59 +118,23 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
-    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -295,11 +259,50 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/vite-plugin@3.0.0-next.32':
-    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -335,15 +338,6 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  babel-preset-solid@2.0.0-rc.2:
-    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.2
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   baseline-browser-mapping@2.8.26:
     resolution: {integrity: sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==}
@@ -581,9 +575,6 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.27:
-    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
-
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -756,56 +747,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -814,12 +764,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -850,10 +805,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -910,16 +865,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
   '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.28.5)
+      '@solidjs/compiler': 2.0.0-rc.3
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
       solid-js: 2.0.0-rc.3
       vite: 8.1.5(@types/node@24.13.3)
@@ -962,13 +958,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1151,17 +1140,6 @@ snapshots:
       picocolors: 1.1.1
 
   validate-html-nesting@1.2.4: {}
-
-  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
-    dependencies:
-      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
-    transitivePeerDependencies:
-      - '@solidjs/start-devtools'
-      - '@solidjs/web'
-      - '@testing-library/jest-dom'
-      - solid-js
-      - supports-color
-      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/incrementing-render-effect/vite.config.ts
+++ b/frameworks/solid-2/incrementing-render-effect/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/frameworks/solid-2/one-item-many-updates/package.json
+++ b/frameworks/solid-2/one-item-many-updates/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.27"
+    "@solidjs/vite-plugin": "3.0.0-next.34"
   }
 }

--- a/frameworks/solid-2/one-item-many-updates/package.json
+++ b/frameworks/solid-2/one-item-many-updates/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.27",
+    "@solidjs/web": "2.0.0-rc.3",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.27"
+    "solid-js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.17"
+    "vite-plugin-solid": "3.0.0-next.27"
   }
 }

--- a/frameworks/solid-2/one-item-many-updates/pnpm-lock.yaml
+++ b/frameworks/solid-2/one-item-many-updates/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.17
-        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,44 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
-    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
-    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
+    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
-    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
+    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
-    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
+    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
-    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
+    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.31':
-    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
+  '@dom-expressions/compiler@0.50.0-next.44':
+    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -295,13 +295,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.27':
-    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.27':
-    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
+  '@solidjs/vite-plugin@3.0.0-next.32':
+    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      solid-js: ^2.0.0-beta.27
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -321,11 +336,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.27:
-    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.27
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -535,8 +550,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.27:
-    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -566,16 +581,8 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.17:
-    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
+  vite-plugin-solid@3.0.0-next.27:
+    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -749,7 +756,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -759,36 +766,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.31':
+  '@dom-expressions/compiler@0.50.0-next.44':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -903,13 +910,28 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.27': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
+  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.28.5
+      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.3
+      vite: 8.1.5(@types/node@24.13.3)
+      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -941,12 +963,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1101,9 +1123,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.27:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.27
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1130,20 +1152,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.31
-      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.27
-      vite: 8.1.5(@types/node@24.13.3)
-      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:
+      - '@solidjs/start-devtools'
+      - '@solidjs/web'
+      - '@testing-library/jest-dom'
+      - solid-js
       - supports-color
+      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/one-item-many-updates/pnpm-lock.yaml
+++ b/frameworks/solid-2/one-item-many-updates/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
@@ -27,9 +30,6 @@ importers:
       vite:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.27
-        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,59 +118,23 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
-    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -295,11 +259,50 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/vite-plugin@3.0.0-next.32':
-    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -335,15 +338,6 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  babel-preset-solid@2.0.0-rc.2:
-    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.2
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   baseline-browser-mapping@2.8.26:
     resolution: {integrity: sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==}
@@ -581,9 +575,6 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.27:
-    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
-
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -756,56 +747,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -814,12 +764,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -850,10 +805,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -910,16 +865,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
   '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.28.5)
+      '@solidjs/compiler': 2.0.0-rc.3
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
       solid-js: 2.0.0-rc.3
       vite: 8.1.5(@types/node@24.13.3)
@@ -962,13 +958,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1151,17 +1140,6 @@ snapshots:
       picocolors: 1.1.1
 
   validate-html-nesting@1.2.4: {}
-
-  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
-    dependencies:
-      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
-    transitivePeerDependencies:
-      - '@solidjs/start-devtools'
-      - '@solidjs/web'
-      - '@testing-library/jest-dom'
-      - solid-js
-      - supports-color
-      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/one-item-many-updates/vite.config.ts
+++ b/frameworks/solid-2/one-item-many-updates/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],

--- a/frameworks/solid-2/ten-k-items-one-time/package.json
+++ b/frameworks/solid-2/ten-k-items-one-time/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.27"
+    "@solidjs/vite-plugin": "3.0.0-next.34"
   }
 }

--- a/frameworks/solid-2/ten-k-items-one-time/package.json
+++ b/frameworks/solid-2/ten-k-items-one-time/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.27",
+    "@solidjs/web": "2.0.0-rc.3",
     "common": "link:../../../common",
-    "solid-js": "2.0.0-beta.27"
+    "solid-js": "2.0.0-rc.3"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-solid": "3.0.0-next.17"
+    "vite-plugin-solid": "3.0.0-next.27"
   }
 }

--- a/frameworks/solid-2/ten-k-items-one-time/pnpm-lock.yaml
+++ b/frameworks/solid-2/ten-k-items-one-time/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27(solid-js@2.0.0-beta.27)
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       common:
         specifier: link:../../../common
         version: link:../../../common
       solid-js:
-        specifier: 2.0.0-beta.27
-        version: 2.0.0-beta.27
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -28,8 +28,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
       vite-plugin-solid:
-        specifier: 3.0.0-next.17
-        version: 3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3))
+        specifier: 3.0.0-next.27
+        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,44 +118,44 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32':
-    resolution: {integrity: sha512-efll+wkPLncFZJ8FAEOfMQS0TcakqO/QHjjgxMnDWAfl+q/GmnHFaKwHnz4j3Dw30s9/0gONHU0brEtt2se6KA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
+    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
-    resolution: {integrity: sha512-vAQXAZaUUm3pL4B8xfl0y8vtgkM26Y3mRAQRv3wRi/aoyPJ58iUoDqkPnojMranzjlLyDHKA1wAheA6jtLcMVg==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
+    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
-    resolution: {integrity: sha512-JG2D/Iy6cegNmU4m2N+bDnCmsV9TarG1atG4ELMQMipwMLIOG3/SulfBeY1OyG8DGCgY3QlFUklsTri9zSeiJg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
+    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-0u5VedlDKqh3Qq6/PyTtg7NiDzwc7nbUuSDrMZPVq0LbrZLsreXlTuWF++c+rfWxHo4Y8ZtPzAVbVYOiTSXr+A==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
-    resolution: {integrity: sha512-3EC/P2GE0jIVvIHYIBNXmiBp4c9Qfe2Rb2dEuIygqoIaChRVySgHCOmshMFZ+lNRqmBhMCtcQN2EYA/UCVfLdw==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
+    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
-    resolution: {integrity: sha512-5PctEhNOMtcNRG+q7MiqYqScQu8dfseXFZH5ZrQCMoFGHfARL5/krEYT1/sA53GSYgRsQMCy2Jnq9LzZa+1/wQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
+    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
-    resolution: {integrity: sha512-nS+bnkBcPdvU5FZO+Bzl9umSAuspwpAp15lZa0MOelTo9KI/cJWvErWizshajfuEJoGk4SG8vaCR38wRoxOM/w==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
+    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.31':
-    resolution: {integrity: sha512-tiOKPFkRsnTis14A1fSf342fn+d0R/nx504P/1qKUBuv5Ha5ORa9r2CZtBgTsOim8ZkZCqylAjFb5Hv74XI1Nw==}
+  '@dom-expressions/compiler@0.50.0-next.44':
+    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -295,13 +295,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solidjs/signals@2.0.0-beta.27':
-    resolution: {integrity: sha512-dSTaBfKigd58K+INKvzesxmAw/mnBEIYrdNI+a8K1hDVrSC7oil7bS36bI98ltua/Vfr9XZ+rPIQoFXtaqtgbw==}
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/web@2.0.0-beta.27':
-    resolution: {integrity: sha512-RceyVg+rf8OZJ/c6kB3Qsz1kE6arrakyRArBypAnxGmhwC89pxltSgET6Stusngl2kUdeiai/NR4LMTJwWO9OQ==}
+  '@solidjs/vite-plugin@3.0.0-next.32':
+    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      solid-js: ^2.0.0-beta.27
+      '@solidjs/start-devtools': ^1.0.0-next.2
+      '@solidjs/web': ^2.0.0-rc.0
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^2.0.0-rc.0
+      vite: ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      '@solidjs/start-devtools':
+        optional: true
+      '@testing-library/jest-dom':
+        optional: true
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -321,11 +336,11 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  babel-preset-solid@2.0.0-beta.27:
-    resolution: {integrity: sha512-WBAZIWoEHrFzivCWJCwb+rKOYmnTaMmeXejumfIem8NZagiomBi/OokGYON3RqQ7sZQxVRAXIh9Obvk10MhU8g==}
+  babel-preset-solid@2.0.0-rc.2:
+    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.27
+      solid-js: ^2.0.0-rc.2
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -535,8 +550,8 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-beta.27:
-    resolution: {integrity: sha512-HXi34dKdrdOCGnG4Ocsz/md1kgWY1M3srK/joYk+Si+7a2uaEN43G4szRriWrjsj5pBg+3I9JxLQmnaFH+lDnw==}
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -566,16 +581,8 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.17:
-    resolution: {integrity: sha512-CiRkXOh92XKvyyRseoCSVH5uQlmTuK04JmsPtsodyJx2N2IQrbCfYhS2wIqFmMe7Y/Aigkm3tOCW4xrLra8wbg==}
-    peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.26 <2.0.0-experimental.0'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@testing-library/jest-dom':
-        optional: true
+  vite-plugin-solid@3.0.0-next.27:
+    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -749,7 +756,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.32(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -759,36 +766,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.31':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.31':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.31':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.31':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.31':
+  '@dom-expressions/compiler@0.50.0-next.44':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.31
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.31
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.31
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.31
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -903,13 +910,28 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solidjs/signals@2.0.0-beta.27': {}
+  '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27)':
+  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/core': 7.28.5
+      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-rc.3
+      vite: 8.1.5(@types/node@24.13.3)
+      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -941,12 +963,12 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  babel-preset-solid@2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.32(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.27
+      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1101,9 +1123,9 @@ snapshots:
 
   seroval@1.5.6: {}
 
-  solid-js@2.0.0-beta.27:
+  solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.27
+      '@solidjs/signals': 2.0.0-rc.3
       csstype: 3.1.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -1130,20 +1152,16 @@ snapshots:
 
   validate-html-nesting@1.2.4: {}
 
-  vite-plugin-solid@3.0.0-next.17(@solidjs/web@2.0.0-beta.27(solid-js@2.0.0-beta.27))(solid-js@2.0.0-beta.27)(vite@8.1.5(@types/node@24.13.3)):
+  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.31
-      '@solidjs/web': 2.0.0-beta.27(solid-js@2.0.0-beta.27)
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.27(@babel/core@7.28.5)(solid-js@2.0.0-beta.27)
-      merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.27
-      vite: 8.1.5(@types/node@24.13.3)
-      vitefu: 1.1.1(vite@8.1.5(@types/node@24.13.3))
+      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
     transitivePeerDependencies:
+      - '@solidjs/start-devtools'
+      - '@solidjs/web'
+      - '@testing-library/jest-dom'
+      - solid-js
       - supports-color
+      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/ten-k-items-one-time/pnpm-lock.yaml
+++ b/frameworks/solid-2/ten-k-items-one-time/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 2.0.0-rc.3
         version: 2.0.0-rc.3
     devDependencies:
+      '@solidjs/vite-plugin':
+        specifier: 3.0.0-next.34
+        version: 3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
@@ -27,9 +30,6 @@ importers:
       vite:
         specifier: ^8.1.1
         version: 8.1.5(@types/node@24.13.3)
-      vite-plugin-solid:
-        specifier: 3.0.0-next.27
-        version: 3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
 
@@ -118,59 +118,23 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44':
-    resolution: {integrity: sha512-f1kx6TeMQgaLVkGfuxMn0BkH0+HvsycFf1qPHbYoBqmBQd6Ag/EXOxkSpfcaC+UOBMSaF4BKXegGDchRNTWKrg==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    resolution: {integrity: sha512-7l575p7EQu16lssfbtgspSBWBSK5+car5NP4VYD/iJiK+Qd2VcMQMwaOjgA1xCs/P0S0l9EFY9BHGIJcHQTL+w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    resolution: {integrity: sha512-NRbfI3HhBPsSrSQvSUfQXvPXfEKjUQKnbBVCDvcu7ISBPMQd+0yH9M+Qmlf7kVq4Ci9qa1HL5EA2jD22d2v73A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-/Gfa8j/YHBKK1i8b2VQw3ewBlA6qlEZSAn+b7g3z1g18WydPUI/TZWISKpgNxAtyl9m9MvwgbWA1HcHVkf4zyg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    resolution: {integrity: sha512-gV4J4Sr1+6Awnkl5npREqPvxcDfgw4PGguTdFnsHVN9cxAFet3ujcCbWsAJ+QMBUQ8OT/LG6d4oJLlAkQ0D1fA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    resolution: {integrity: sha512-YrzoB/YZtrmnGXhz3sxs7VeuAXT0JRc6NguNX8iDNt5p5fQ0QX+HR75GYMsxY9FceSVTHObrm3fA/8KGYo5z6Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    resolution: {integrity: sha512-BNQEgny4zyjceZqCaRJDCrQ2oy6z7oXruAE/du2uJB7qLz/z24ISJVUKeKHPb5mRzHuSiTlDcK7pDzE7jPPXjg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    resolution: {integrity: sha512-CBj0k+LcpCk8+nJGY7uvqxLC5NLxXTx9l0fuMZBBkBAOgVf5/IlMyMSpaYE5H5AkFiajR05NYvNR07R6e0KZ3w==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -295,11 +259,50 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3':
+    resolution: {integrity: sha512-VLqCvvMukrACeMuF3uPTyx9l+qCQ9H1G25vOl7FXAdu9rMrLEKZ2IEoiUMczn0mhXAVeplJVEvr7+gSy5m4omA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    resolution: {integrity: sha512-P9Ngf6KUwM+KGAAUZ40776+1utbk/n3+F+WhyyYm+rUpjO0um9EqBJLvafqEp6kGgSHQ2j5UhioqcuqhesMLbQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    resolution: {integrity: sha512-PozalaeiMJxPF7H5ePpqOGM8F9H07sFsSGxyHHZiUn8c4HIBlsacNpc06gUcoJ1xzm7AvayNCV9BJOw2hQYaYg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-riY4uwHCqq5vfrlYY7AK8xy/r/Wd98NCnbGqFsDb7bL7TNw398VuA5+hoK4cnsQJe4dqvI2zXFEdmP5xSNAFSQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    resolution: {integrity: sha512-y2GlcmfIqtWBrxOnvgLsGZvdH2tVK/9JzcFTUzWo5kjoiEy+VCV3NSNcBZrMbLJ7ozIDTiuWePZd/G5LphYdmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    resolution: {integrity: sha512-mx7LnrAwKaXd9ZiaAwZeBlMjdWNdmR73F+3I1iOxSpH9Lh2Kyx9IIVff0a1AnwUy17tdDxXMbWxoI/ctYfZsdw==}
+    engines: {node: '>=14.0.0'}
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    resolution: {integrity: sha512-7MQDvdSI42/+lSac6L6WVgCYkUezzliLRoCjo7ultpN2hHy3XgohxvrWfE005OQEMg2pamzzFmfeIl8FUi2JRA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    resolution: {integrity: sha512-gu2AnJwkrJfk3SBKGRxEUGuP/SZpwUGzHQS5zt56eNG4GFlEMyurahVRSLMWWBhtC1On7wH5SmLxybH2yDCqAg==}
+
   '@solidjs/signals@2.0.0-rc.3':
     resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
-  '@solidjs/vite-plugin@3.0.0-next.32':
-    resolution: {integrity: sha512-ql+AdWuMwMnZLLYuBgejJxRtX7ak0Hu4ejtCiPMBplJjpvczzYV/ruvWIg4HA1YW24GkJ9wUy5TNjEk3O1c1pA==}
+  '@solidjs/vite-plugin@3.0.0-next.34':
+    resolution: {integrity: sha512-uDxBcBjbcS6k509TXTsNw4PjubT59eInzLAny43N5Ieoa4jROCaWV+EwxedPqtCF7nsHoKGgwC+ysu6w105G0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@solidjs/start-devtools': ^1.0.0-next.2
@@ -335,15 +338,6 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  babel-preset-solid@2.0.0-rc.2:
-    resolution: {integrity: sha512-Venq++Aa6+RzGIAyS5vSo3kX1fE8zRreEPCh1eTh5DTjlTft9qZGIG14RSZDv/sjVxT8x5Gs9+21PzxuLe8U+g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.2
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   baseline-browser-mapping@2.8.26:
     resolution: {integrity: sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==}
@@ -581,9 +575,6 @@ packages:
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
-  vite-plugin-solid@3.0.0-next.27:
-    resolution: {integrity: sha512-bDzjIIplkSDH73BiGP9pbPR3ZnjeUA18SAYugLhqDCy4u0bl3qdrETstxrXuo2vHXLB0VD9rvOr0iesZBBul4Q==}
-
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -756,56 +747,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.44(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.44':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.44':
-    optional: true
-
-  '@dom-expressions/compiler@0.50.0-next.44':
-    optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.44
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.44
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.44
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.44
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -814,12 +764,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -850,10 +805,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -910,16 +865,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/babel-plugin@2.0.0-rc.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3':
+    optional: true
+
+  '@solidjs/compiler@2.0.0-rc.3':
+    optionalDependencies:
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.3
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.3
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.3
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.3
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.3
+
   '@solidjs/signals@2.0.0-rc.3': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
+  '@solidjs/vite-plugin@3.0.0-next.34(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.28.5
-      '@dom-expressions/compiler': 0.50.0-next.44
+      '@solidjs/babel-plugin': 2.0.0-rc.3(@babel/core@7.28.5)
+      '@solidjs/compiler': 2.0.0-rc.3
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3)
       merge-anything: 5.1.7
       solid-js: 2.0.0-rc.3
       vite: 8.1.5(@types/node@24.13.3)
@@ -962,13 +958,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.28.5)(solid-js@2.0.0-rc.3):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.28.5)
-    optionalDependencies:
-      solid-js: 2.0.0-rc.3
 
   baseline-browser-mapping@2.8.26: {}
 
@@ -1151,17 +1140,6 @@ snapshots:
       picocolors: 1.1.1
 
   validate-html-nesting@1.2.4: {}
-
-  vite-plugin-solid@3.0.0-next.27(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3)):
-    dependencies:
-      '@solidjs/vite-plugin': 3.0.0-next.32(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)(vite@8.1.5(@types/node@24.13.3))
-    transitivePeerDependencies:
-      - '@solidjs/start-devtools'
-      - '@solidjs/web'
-      - '@testing-library/jest-dom'
-      - solid-js
-      - supports-color
-      - vite
 
   vite@8.1.5(@types/node@24.13.3):
     dependencies:

--- a/frameworks/solid-2/ten-k-items-one-time/src/App.tsx
+++ b/frameworks/solid-2/ten-k-items-one-time/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onSettled, Repeat } from 'solid-js'
+import { createSignal, createRenderEffect, onSettled, Repeat, type JSX } from 'solid-js'
 import { helpers } from 'common';
 
 const test = helpers.tenKitems1UpdateEach();
@@ -18,7 +18,16 @@ function App() {
     <Repeat count={items.length}>
       {index => {
         const item = items[index]![0];
-        return <>{test.formatItem(item())}</>;
+        // a bare text child (`<>{...}</>`) would flatten into the parent
+        // insert, which then re-normalizes the whole list on every update;
+        // owning the node keeps each update a per-row `.data` write
+        // (same pattern the solid-1 app uses)
+        const node = document.createTextNode('');
+        createRenderEffect(
+          () => test.formatItem(item()),
+          v => { node.data = v; },
+        );
+        return node as unknown as JSX.Element;
       }}
     </Repeat>
   )

--- a/frameworks/solid-2/ten-k-items-one-time/vite.config.ts
+++ b/frameworks/solid-2/ten-k-items-one-time/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
+import solid from '@solidjs/vite-plugin'
 
 export default defineConfig({
   plugins: [solid()],


### PR DESCRIPTION
## Summary

- Bumps all five solid-2 apps from `2.0.0-beta.27` to `2.0.0-rc.3`.
- Moves to `@solidjs/vite-plugin@3.0.0-next.34` — the Vite plugin was renamed from `vite-plugin-solid`, and next.34 is the release paired with rc.3.
- rc.3 ships a runtime fix directly relevant to dbmon: dynamic text sharing a slot with element siblings (the five `elapsed` cells per row — `{query().elapsed}` next to the popover div) previously allocated a fresh text node and swapped it in on every change. It now updates the existing node's `data` in place, at commit time.
- One app change: the ten-k app now owns its row text nodes, matching what the solid-1 app already does (details below).

## dbmon numbers

Measured with your own in-page fps marks (5×5s windows), headless Chrome, 8x CPU throttle, `?rows=100` (200 table rows) to get everyone off the vsync ceiling, back-to-back on the same machine:

| build | fps (5 samples) | text nodes recreated / run |
| --- | --- | --- |
| solid-2 beta.27 (current main) | ~13.5 | ~660k |
| **solid-2 rc.3 (this PR)** | **27–37** | ~0 (~800k in-place data writes) |
| solid-1 (reference, same session) | 22–24 | ~130k |

At the default 20 row-pairs everything sits at the frame cap, so differences only show under load. Numbers from my harness-reading script rather than the full runner, so treat them as directional — but the DOM-churn profile change (measured with a MutationObserver on the tbody) is deterministic, not noise.

## ten-k app fix (the `(async)` rows)

The solid-2 ten-k app had bare text at the top level of each `Repeat` row (`<>{item()}</>`). That flattens into the parent insert, which then subscribes to every row's signal and re-normalizes the whole 10k-entry list on every update. Sync runs hide it (one flush at the end), but the `(async)` variant flushes per update, making it quadratic.

The solid-1 app already sidesteps this by owning a text node per row and writing `.data` — the comment in that file describes this exact trap. This PR applies the same pattern to solid-2, restoring identical work between the two Solid apps. Async variant (`?percentRandomAwait=100`, `:start`→`:done`, median of 3):

| build | async | sync |
| --- | --- | --- |
| solid-2 bare-text rows (before) | 4,142 ms | 7 ms |
| **solid-2 owned-node (this PR)** | **9 ms** | 6 ms |
| solid-1 (reference) | 6 ms | 5 ms |

## fan-out (write-side fast path)

The recorded fan-out rows also predate rc.3. beta.27 re-walked all 1,000 subscribers on every write, so the single-burst variant (10k writes, one flush) paid ~10M subscriber visits. rc.3 re-stages repeated writes to an already-notified signal and returns. Same machine, same harness, unthrottled:

| burst size | beta.27 | rc.3 |
| --- | --- | --- |
| 100 | 51 ms | 22 ms |
| 10,000 | 29 ms | 2 ms |

No app change involved -- this is purely the runtime bump.

## Test plan

- [x] All five apps build on rc.3 + @solidjs/vite-plugin next.34
- [x] All five apps run to `:done` / produce fps marks headless with no console or page errors (seed default)
- [x] ten-k verified correct via the bench's own `:done` DOM gate, sync and async variants
- [ ] A full `pnpm bench` run on real hardware for the published result set

Made with [Cursor](https://cursor.com)
